### PR TITLE
feat(signing): add user login endpoint

### DIFF
--- a/__tests__/authRoutes.test.js
+++ b/__tests__/authRoutes.test.js
@@ -44,6 +44,50 @@ describe('User signup tests', () => {
     });
   });
 });
+
+describe('test for user login', () => {
+  it('should login a user account successfully', (done) => {
+    chai
+      .request(app)
+      .post(`${url}/auth/signin`)
+      .send(mockUsers[6])
+      .end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body.message).to.eql('You have successfully logged in');
+        expect(res.body.user).to.have.property('token');
+        expect(res.body.user).to.have.property('isVerified');
+        expect(res.body.user).to.have.property('email');
+        expect(res.body.user.email).to.eql(mockUsers[6].email);
+        done();
+      });
+  });
+  it('should return an error when an email is wrong', (done) => {
+    chai
+      .request(app)
+      .post(`${url}/auth/signin`)
+      .send(mockUsers[7])
+      .end((err, res) => {
+        expect(res.status).to.eql(401);
+        expect(res.body).to.have.property('message');
+        expect(res.body.message).to.eql('You Entered an incorrect Email or Password');
+        done();
+      });
+  });
+  it('should return an error when password is wrong', (done) => {
+    chai
+      .request(app)
+      .post(`${url}/auth/signin`)
+      .send(mockUsers[8])
+      .end((err, res) => {
+        expect(res.status).to.eql(401);
+        expect(res.body).to.have.property('message');
+        expect(res.body.message).to.eql('You Entered an incorrect Email or Password');
+        done();
+      });
+  });
+});
+
+
 describe('Auth Routes Test', () => {
   before((done) => {
     const user = {

--- a/__tests__/mockData/mockUsers.js
+++ b/__tests__/mockData/mockUsers.js
@@ -29,6 +29,18 @@ const users = [
     lastName: 'Potter',
     email: 'harrypott@mail.com',
     password: 'Password1',
+  },
+  {
+    email: 'harrypott@mail.com',
+    password: 'Password1',
+  },
+  {
+    email: 'harrypot@mail.com',
+    password: 'Password1',
+  },
+  {
+    email: 'harrypot@mail.com',
+    password: 'Password',
   }
 ];
 

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -25,7 +25,7 @@ export default class AuthController {
    */
   static async signUp(req, res) {
     const {
-      firstName, lastName, email, password,
+      firstName, lastName, email, password
     } = req.body;
 
     const foundUser = await User.findOne({ where: { email } });
@@ -49,7 +49,7 @@ export default class AuthController {
     const registeredUser = await User.create(user);
     const token = Helper.createToken({
       id: registeredUser.id,
-      email,
+      email
     });
     return res.status(201).send({
       message: 'Your Account has been created successfully!',
@@ -61,7 +61,56 @@ export default class AuthController {
         email: registeredUser.email,
         isVerified: registeredUser.isVerified,
         verificationToken,
-      },
+      }
+    });
+  }
+
+  /**
+   *
+   * @static
+   * @param {object} req express request object
+   * @param {object} res express response object
+   * @returns {object} returns user data
+   * @memberof AuthController
+   */
+  static async userSignin(req, res) {
+    const { email, password } = req.body;
+
+    const user = await models.User.findOne({ where: { email } });
+
+    if (!user) {
+      return res.status(401).send({
+        message: 'You Entered an incorrect Email or Password'
+      });
+    }
+    const {
+      id, firstName, lastName, email: emailAddress, isVerified, type
+    } = user.dataValues;
+
+    const token = Helper.createToken({
+      id,
+      firstName,
+      lastName,
+      emailAddress,
+      isVerified,
+      type,
+    });
+
+    const comparePassword = await Helper.comparePassword(password, user.dataValues.password);
+    if (!comparePassword) {
+      return res.status(401).send({
+        message: 'You Entered an incorrect Email or Password'
+      });
+    }
+    return res.status(200).send({
+      message: 'You have successfully logged in',
+      user: {
+        token,
+        email,
+        firstName,
+        lastName,
+        isVerified,
+      }
     });
   }
 

--- a/docs/auth/login.json
+++ b/docs/auth/login.json
@@ -1,0 +1,99 @@
+{
+  "post": {
+    "tags": ["Auth"],
+    "summary": "Sign in user",
+    "description": "Login Existing User",
+    "parameters": [
+      {
+        "name": "Login Existing User",
+        "in": "body",
+        "description": "request payload",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "example": "emekaofe@gmail.com"
+            },
+            "password": {
+              "type": "string",
+              "example": "pa55w0rd"
+            }
+          }
+        }
+      }
+    ],
+    "produces": ["application/json"],
+    "responses": {
+      "200": {
+        "description": "Login successful",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "number",
+              "example": 200
+            },
+            "method": {
+              "type": "string",
+              "example": "POST"
+            },
+            "message": {
+              "type": "string",
+              "example": "You have successfully logged in"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "token": {
+                  "type": "string",
+                  "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiI1YjA0ZWRiMDZiZDc2MTQwMzgyOWNkMzkiLCJuYW1lIjoiQW1vcyBUb2JpIiwiZW1haWwiOiJ0b2JpQGdva2FkYS5uZyIsImlhdCI6MTUyNzA0OTY0OSwiZXhwIjoxNTI3MTM2MDQ5fQ.-mrtcyVbcCmfyP7HovesvPLT4CFD3kCLzmY24BbKPcU"
+                },
+                "firstname": {
+                  "type": "string",
+                  "example": "Tunji"
+                },
+                "lastname": {
+                  "type": "string",
+                  "example": "Abioye"
+                },
+                "email": {
+                  "type": "string",
+                  "example": "emekaofe@gmail.com"
+                },
+                "isVerified": {
+                  "type": "boolean",
+                  "example": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "401": {
+        "description": "Invalid Login Credentials",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "number",
+              "example": 401
+            },
+            "method": {
+              "type": "string",
+              "example": "POST"
+            },
+            "message": {
+              "type": "string",
+              "example": "You Entered an incorrect Email or Password"
+            },
+            "data": {
+              "type": "string",
+              "example": null
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/index.js
+++ b/docs/index.js
@@ -1,8 +1,10 @@
 import swagger from './swagger.json';
 import logout from './auth/logout.json';
 import signup from './auth/signup.json';
+import login from './auth/login.json';
 
 swagger.paths['/auth/signup'] = signup;
+swagger.paths['/auth/signin'] = login;
 swagger.paths['/auth/logout'] = logout;
 
 

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -18,5 +18,35 @@
   "consumes": ["application/json"],
   "produces": ["application/json"],
   "paths": {},
-  "definitions": {}
+  "definitions": {
+    "Users": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number"
+        },
+        "email": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "isVerified": {
+          "type": "boolean"
+        },
+        "createdOn": {
+          "type": "date"
+        }
+      }
+    }
+  }
 }

--- a/helpers/Auth.js
+++ b/helpers/Auth.js
@@ -1,5 +1,5 @@
 import jwt from 'jsonwebtoken';
-import { hashSync } from 'bcryptjs';
+import { hashSync, compareSync } from 'bcryptjs';
 import { config } from 'dotenv';
 
 config();
@@ -25,6 +25,17 @@ class Helper {
    */
   static hashPassword(password) {
     return hashSync(password, 10);
+  }
+
+  /**
+   * @method comparePassword
+   * @description compares the user inputed password with hashPassword
+   * @param {string} password - The user password to be compared
+   * @param {string} hashPassword - The hashed password in the database
+   * @returns {string} A hashed password
+   */
+  static comparePassword(password, hashPassword) {
+    return compareSync(password, hashPassword);
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1945,6 +1945,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -3,12 +3,13 @@ import AuthController from '../controllers/AuthController';
 import AuthMiddleware from '../middlewares/Authentication';
 import Validate from '../middlewares/inputValidation';
 
-const { signUp, logout } = AuthController;
+const { signUp, userSignin, logout } = AuthController;
 const { verifyToken } = AuthMiddleware;
 
 const router = Router();
 
 router.post('/signup', Validate.signup, signUp);
+router.post('/signin', userSignin);
 router.post('/logout', verifyToken, logout);
 
 


### PR DESCRIPTION

### What does this PR do?

- Creates functionality for users to signing

#### Description of Task to be completed?
- When a user goes to the landing page of author's haven, then the user should be able to login to his account
- User should be able to sign up via the route: `api/v1/auth/signin`
- Document login endpoint using swagger.json
- Write tests to validate controller

#### How should this be manually tested?
After cloning this repo, `cd` into it and do the following:

```bash
# fetch this branch
$ git fetch origin ft-user-signing-167165054

# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run server
```

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#167165054](https://www.pivotaltracker.com/story/show/167165054)

#### Screenshots (if appropriate)


<img width="1285" alt="Screenshot 2019-07-28 at 5 52 31 PM" src="https://user-images.githubusercontent.com/40548599/62010583-b3a08c00-b164-11e9-8a94-6f8eeefd3541.png">
