### PR TITLE
#167570345 Add Confirm Password for User Registration

### DIFF
--- a/__tests__/authRoutes.test.js
+++ b/__tests__/authRoutes.test.js
@@ -43,6 +43,17 @@ describe('User signup tests', () => {
         });
     });
   });
+  it('should return an error when password and confirmPassword does not match', (done) => {
+    chai
+      .request(app)
+      .post(`${url}/auth/signup`)
+      .send(mockUsers[9])
+      .end((err, res) => {
+        expect(res.status).to.eql(400);
+        expect(res.body.errors.password).to.eql('Passwords don\'t match.');
+        done();
+      });
+  });
 });
 
 describe('test for user login', () => {

--- a/__tests__/mockData/mockUsers.js
+++ b/__tests__/mockData/mockUsers.js
@@ -57,8 +57,14 @@ const users = [
   {
     email: 'harrypotter@mail.com',
     password: '',
-  }
+  },
+  {
+    firstName: 'Harry',
+    lastName: 'Potter',
+    email: 'harrypott@mail.com',
+    password: 'Password1',
+    confirmPassword: 'Password',
+  },
 ];
-
 
 export default users;

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -25,7 +25,7 @@ export default class AuthController {
    */
   static async signUp(req, res) {
     const {
-      firstName, lastName, email, password
+      firstName, lastName, email, password, confirmPassword
     } = req.body;
     const genericWordsArray = [firstName, lastName, 'password', 123];
     const genericWord = genericWordsArray.find(word => password.includes(word));
@@ -43,6 +43,12 @@ export default class AuthController {
         message: 'This User already exist',
       });
     }
+
+    if (password !== confirmPassword) {
+      return res.status(400).send({
+        message: "Password doesn't match, Please check you are entering the right thing!",
+      });
+    }
     const hashedPassword = Helper.hashPassword(password);
     const verificationToken = Helper.hashUserData(email);
     const user = {
@@ -58,7 +64,8 @@ export default class AuthController {
     const registeredUser = await User.create(user);
     const token = Helper.createToken({
       id: registeredUser.id,
-      email
+      email,
+      type: registeredUser.type,
     });
     return res.status(201).send({
       message: 'Your Account has been created successfully!',
@@ -89,7 +96,7 @@ export default class AuthController {
 
     if (!user) {
       return res.status(401).send({
-        message: 'You Entered an incorrect Email or Password'
+        message: 'You Entered an incorrect Email or Password',
       });
     }
     const {
@@ -108,7 +115,7 @@ export default class AuthController {
     const comparePassword = await Helper.comparePassword(password, user.dataValues.password);
     if (!comparePassword) {
       return res.status(401).send({
-        message: 'You Entered an incorrect Email or Password'
+        message: 'You Entered an incorrect Email or Password',
       });
     }
     return res.status(200).send({


### PR DESCRIPTION
## What does this PR do?
- Add `confirm password` field to the user registration data 

#### Description of Task to be completed?
- User should be able to re-enter  `password` in the `confirm password` field
- An error should be thrown if passwords do not match

#### How should this be manually tested?
1. Fetch this branch on the terminal using
 `git fetch origin ch-confirm-password-1167570345`
3. Install dependencies using npm install
4. Start the server with npm run server
5. On Postman, sign up by making a POST request to `/api/v1/auth/signup`
6. Enter the password and confirm password field

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[167570345](!https://www.pivotaltracker.com/story/show/167570345)

#### Screenshots (if appropriate)
<img width="1280" alt="Screenshot 2019-07-29 at 3 44 22 PM" src="https://user-images.githubusercontent.com/40548599/62058470-6cc09e00-b219-11e9-81fa-01d327bf1c9a.png">

- When password doesn't match
<img width="1278" alt="Screenshot 2019-07-30 at 9 37 17 AM" src="https://user-images.githubusercontent.com/40548599/62114407-84963180-b2ae-11e9-8c07-1d2a5f9dbade.png">

