### PR TITLE
#167165058 Reset Password feature

### DIFF
--- a/__tests__/authRoutes.test.js
+++ b/__tests__/authRoutes.test.js
@@ -4,17 +4,17 @@ import chaiHttp from 'chai-http';
 import app from '..';
 import models from '../database/models';
 import mockUsers from './mockData/mockUsers';
-import mockUsersToVerify from './mockData/mockUsersToVerify';
+
 
 chai.use(chaiHttp);
 
 const API_PREFIX = '/api/v1/auth';
 const url = '/api/v1';
 const { expect } = chai;
-const { BlacklistedToken, User } = models;
+const { BlacklistedToken } = models;
 let validUserToken;
 const blacklistedToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoiSm9obiIsImlhdCI6MTU2NDAwOTA5NCwiZXhwIjoxNTY0MDEyNjk0fQ.J5ktoXlmLxOtV8R16sNPMXXeydwRdCA8h6Cep-AzZnc';
-const { userToVerify, secondUserToVerify, thirdUserToVerify } = mockUsersToVerify;
+
 
 
 describe('User signup tests', () => {
@@ -193,69 +193,6 @@ describe('Auth Routes Test', () => {
       .end((err, res) => {
         expect(res.status).to.eql(500);
         stub.restore();
-        done();
-      });
-  });
-});
-describe('verifying a user email', () => {
-  let verificationCode;
-  before((done) => {
-    chai.request(app)
-      .post('/api/v1/auth/signup')
-      .send(userToVerify)
-      .end((err, res) => {
-        verificationCode = res.body.user.verificationToken;
-        done();
-      });
-  });
-  it('should return a success response object when a user successfully verifies an email', (done) => {
-    chai.request(app)
-      .patch(`${url}/auth/verify?email=${userToVerify.email}&token=${verificationCode}`)
-      .end((err, res) => {
-        expect(res.status).to.eql(200);
-        expect(res.body.message).to.eql('Email Verified');
-        expect(res.body.isVerified).to.eql(true);
-        done();
-      });
-  });
-  let secondVerificationCode;
-  before((done) => {
-    chai.request(app)
-      .post('/api/v1/auth/signup')
-      .send(secondUserToVerify)
-      .end((err, res) => {
-        secondVerificationCode = res.body.user.verificationToken;
-        done();
-      });
-  });
-  it('should throw an error when user attempts to verify an email with the wrong information', (done) => {
-    chai.request(app)
-      .patch(`${url}/auth/verify?email=${secondUserToVerify.email}&token=${secondVerificationCode.slice(0, 34)}`)
-      .end((err, res) => {
-        expect(res.status).to.eql(400);
-        expect(res.body.message).to.eql('Incorrect Credentials');
-        expect(res.body.isVerified).to.eql(false);
-        done();
-      });
-  });
-  let thirdVerificationCode;
-  before((done) => {
-    chai.request(app)
-      .post('/api/v1/auth/signup')
-      .send(thirdUserToVerify)
-      .end((err, res) => {
-        thirdVerificationCode = res.body.user.verificationToken;
-        done();
-      });
-  });
-  it('should throw a server error when user attempts to verify an email', (done) => {
-    const stub = sinon.stub(User, 'update');
-    const error = new Error('Something went wrong');
-    stub.yields(error);
-    chai.request(app)
-      .patch(`${url}/auth/verify?email=${thirdUserToVerify.email}&token=${thirdVerificationCode}`)
-      .end((err, res) => {
-        expect(res.status).to.eql(500);
         done();
       });
   });

--- a/__tests__/authRoutes.test.js
+++ b/__tests__/authRoutes.test.js
@@ -5,7 +5,6 @@ import app from '..';
 import models from '../database/models';
 import mockUsers from './mockData/mockUsers';
 
-
 chai.use(chaiHttp);
 
 const API_PREFIX = '/api/v1/auth';

--- a/__tests__/authRoutes.test.js
+++ b/__tests__/authRoutes.test.js
@@ -15,7 +15,6 @@ let validUserToken;
 const blacklistedToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoiSm9obiIsImlhdCI6MTU2NDAwOTA5NCwiZXhwIjoxNTY0MDEyNjk0fQ.J5ktoXlmLxOtV8R16sNPMXXeydwRdCA8h6Cep-AzZnc';
 
 
-
 describe('User signup tests', () => {
   describe('test for user signup', () => {
     it('should register a user successfully when all fields are inputed correctly', (done) => {

--- a/__tests__/authRoutes.test.js
+++ b/__tests__/authRoutes.test.js
@@ -4,15 +4,17 @@ import chaiHttp from 'chai-http';
 import app from '..';
 import models from '../database/models';
 import mockUsers from './mockData/mockUsers';
+import mockUsersToVerify from './mockData/mockUsersToVerify';
 
 chai.use(chaiHttp);
 
 const API_PREFIX = '/api/v1/auth';
 const url = '/api/v1';
 const { expect } = chai;
-const { BlacklistedToken } = models;
+const { BlacklistedToken, User } = models;
 let validUserToken;
 const blacklistedToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoiSm9obiIsImlhdCI6MTU2NDAwOTA5NCwiZXhwIjoxNTY0MDEyNjk0fQ.J5ktoXlmLxOtV8R16sNPMXXeydwRdCA8h6Cep-AzZnc';
+const { userToVerify, secondUserToVerify, thirdUserToVerify } = mockUsersToVerify;
 
 
 describe('User signup tests', () => {
@@ -191,6 +193,69 @@ describe('Auth Routes Test', () => {
       .end((err, res) => {
         expect(res.status).to.eql(500);
         stub.restore();
+        done();
+      });
+  });
+});
+describe('verifying a user email', () => {
+  let verificationCode;
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signup')
+      .send(userToVerify)
+      .end((err, res) => {
+        verificationCode = res.body.user.verificationToken;
+        done();
+      });
+  });
+  it('should return a success response object when a user successfully verifies an email', (done) => {
+    chai.request(app)
+      .patch(`${url}/auth/verify?email=${userToVerify.email}&token=${verificationCode}`)
+      .end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body.message).to.eql('Email Verified');
+        expect(res.body.isVerified).to.eql(true);
+        done();
+      });
+  });
+  let secondVerificationCode;
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signup')
+      .send(secondUserToVerify)
+      .end((err, res) => {
+        secondVerificationCode = res.body.user.verificationToken;
+        done();
+      });
+  });
+  it('should throw an error when user attempts to verify an email with the wrong information', (done) => {
+    chai.request(app)
+      .patch(`${url}/auth/verify?email=${secondUserToVerify.email}&token=${secondVerificationCode.slice(0, 34)}`)
+      .end((err, res) => {
+        expect(res.status).to.eql(400);
+        expect(res.body.message).to.eql('Incorrect Credentials');
+        expect(res.body.isVerified).to.eql(false);
+        done();
+      });
+  });
+  let thirdVerificationCode;
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signup')
+      .send(thirdUserToVerify)
+      .end((err, res) => {
+        thirdVerificationCode = res.body.user.verificationToken;
+        done();
+      });
+  });
+  it('should throw a server error when user attempts to verify an email', (done) => {
+    const stub = sinon.stub(User, 'update');
+    const error = new Error('Something went wrong');
+    stub.yields(error);
+    chai.request(app)
+      .patch(`${url}/auth/verify?email=${thirdUserToVerify.email}&token=${thirdVerificationCode}`)
+      .end((err, res) => {
+        expect(res.status).to.eql(500);
         done();
       });
   });

--- a/__tests__/inputValidation.test.js
+++ b/__tests__/inputValidation.test.js
@@ -105,3 +105,21 @@ describe('User signin validation test', () => {
       });
   });
 });
+
+describe('User reset password validation test', () => {
+  const wrongUserEmail = {
+    email: 'johnoluwa@test',
+  };
+  it('should return status 400 if the email input is invalid', (done) => {
+    chai
+      .request(app)
+      .post(`${url}/auth/forgotpassword`)
+      .send(wrongUserEmail)
+      .end((err, res) => {
+        expect(res.status).eql(400);
+        expect(res.body).to.have.property('errors');
+        expect(res.body.errors.email).eql('Please input a valid email address');
+        done();
+      });
+  });
+});

--- a/__tests__/resetPassword.test.js
+++ b/__tests__/resetPassword.test.js
@@ -57,6 +57,22 @@ describe('Reset Password Test', () => {
       });
   });
 
+  it('should return an error if password is not validated', (done) => {
+    const userPassword = {
+      password: '',
+      confirmPassword: '',
+    };
+    chai
+      .request(app)
+      .patch(`${url}/auth/resetpassword/${jwToken}`)
+      .send(userPassword)
+      .end((err, res) => {
+        expect(res.status).to.eql(400);
+        expect(res.body.errors.password).to.eql('Password is required');
+        done();
+      });
+  });
+
   it('should return an error when password and confirmPassword does not match', (done) => {
     const userPassword = {
       password: 'allMyGuysAreBallers1$$',

--- a/__tests__/resetPassword.test.js
+++ b/__tests__/resetPassword.test.js
@@ -1,0 +1,108 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '..';
+
+chai.use(chaiHttp);
+
+const url = '/api/v1';
+const { expect } = chai;
+describe('Reset Password Test', () => {
+  const userEmail = {
+    email: 'johndoe@test.com',
+  };
+  let jwToken;
+  before((done) => {
+    chai
+      .request(app)
+      .post(`${url}/auth/forgotpassword`)
+      .send(userEmail)
+      .end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body.email).to.eql(userEmail.email);
+        expect(res.body.message).to.eql('Your reset link has been sent to your email');
+        const { token } = res.body;
+        jwToken = token;
+        done();
+      });
+  });
+
+  it('should throw an error if the user does not already have an account', (done) => {
+    const fakeUserEmail = {
+      email: 'johnoluwa@test.com',
+    };
+    chai
+      .request(app)
+      .post(`${url}/auth/forgotpassword`)
+      .send(fakeUserEmail)
+      .end((err, res) => {
+        expect(res.status).to.eql(404);
+        expect(res.body.errors.message).to.eql('You are not an existing user, please sign up');
+        done();
+      });
+  });
+
+  it('should return an error when you use a generic password', (done) => {
+    const userPassword = {
+      password: 'Password123',
+      confirmPassword: 'Password123',
+    };
+    chai
+      .request(app)
+      .patch(`${url}/auth/resetpassword/${jwToken}`)
+      .send(userPassword)
+      .end((err, res) => {
+        expect(res.status).to.eql(400);
+        expect(res.body.errors.message).to.eql('Do not use a common word as the password');
+        done();
+      });
+  });
+
+  it('should return an error when password and confirmPassword does not match', (done) => {
+    const userPassword = {
+      password: 'allMyGuysAreBallers1$$',
+      confirmPassword: 'allMyGuysAreNotBallers%%',
+    };
+    chai
+      .request(app)
+      .patch(`${url}/auth/resetpassword/${jwToken}`)
+      .send(userPassword)
+      .end((err, res) => {
+        expect(res.status).to.eql(400);
+        expect(res.body.errors.message).to.eql('Password doesn\'t match, Please check you are entering the right thing!');
+        done();
+      });
+  });
+
+  it('should successfully reset users password', (done) => {
+    const userPassword = {
+      password: 'allMyGuysAreBallers1$$',
+      confirmPassword: 'allMyGuysAreBallers1$$',
+    };
+    chai
+      .request(app)
+      .patch(`${url}/auth/resetpassword/${jwToken}`)
+      .send(userPassword)
+      .end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body.message).to.eql('Your Password has been reset successfully');
+
+        done();
+      });
+  });
+
+  it('should throw an error if the token is used more than once', (done) => {
+    const userPassword = {
+      password: 'allMyGuysAreBallers1$$',
+      confirmPassword: 'allMyGuysAreBallers1$$',
+    };
+    chai
+      .request(app)
+      .patch(`${url}/auth/resetpassword/${jwToken}`)
+      .send(userPassword)
+      .end((err, res) => {
+        expect(res.status).to.eql(409);
+        expect(res.body.errors.message).to.eql('This link has already been used once, please request another link.');
+        done();
+      });
+  });
+});

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -2,9 +2,11 @@ import models from '../database/models';
 import Helper from '../helpers/Auth';
 import ServerResponse from '../modules';
 import EmailVerification from '../helpers/EmailVerification';
+import ForgotPasswordEmail from '../helpers/ForgotPasswordEmail';
 
 const { successResponse } = ServerResponse;
 const { BlacklistedToken, User } = models;
+const { sendResetEmail } = ForgotPasswordEmail;
 
 /**
  *
@@ -237,5 +239,91 @@ export default class AuthController {
     } catch (error) {
       next(error);
     }
+  }
+
+  /**
+   *
+   * @param {*} req express request object
+   * @param {*} res express response object
+   * @returns {object} returns an object depending on the outcome
+   * @memberof AuthController
+   */
+  static async forgotPassword(req, res) {
+    const { email } = req.body;
+    const foundUser = await User.findOne({ where: { email } });
+    if (!foundUser) {
+      return res.status(404).send({
+        errors: {
+          message: 'You are not an existing user, please sign up',
+        }
+      });
+    }
+    const { id } = foundUser.dataValues;
+
+    const token = Helper.createToken({
+      id,
+      email
+    });
+    sendResetEmail(req, email, token);
+    return res.status(200).send({
+      email,
+      token,
+      message: 'Your reset link has been sent to your email'
+    });
+  }
+
+  /**
+   *
+   * @param {*} req express request object
+   * @param {*} res express response object
+   * @returns {object} returns an object depending on the outcome
+   * @memberof AuthController
+   */
+  static async resetPassword(req, res) {
+    const
+      {
+        password,
+        confirmPassword
+      } = req.body;
+    const genericWordsArray = ['Password123', 'Qwerty123', 'Password', 123];
+    const genericWord = genericWordsArray.find(word => password.includes(word));
+    if (genericWord) {
+      return res.status(400).send({
+        errors: {
+          message: 'Do not use a common word as the password',
+        }
+      });
+    }
+    if (password !== confirmPassword) {
+      return res.status(400).send({
+        errors: {
+          message: 'Password doesn\'t match, Please check you are entering the right thing!',
+        }
+      });
+    }
+    const { token } = req.params;
+    const { id, email } = await Helper.verifyToken(token);
+    const foundUser = await User.findOne({ where: { email } });
+    if (!foundUser) {
+      return res.status(404).send({
+        errors: {
+          message: 'You are not an existing user, please sign up',
+        }
+      });
+    }
+    const doubleReset = await BlacklistedToken.findOne({ where: { token } });
+    if (doubleReset) {
+      return res.status(409).send({
+        errors: {
+          message: 'This link has already been used once, please request another link.',
+        }
+      });
+    }
+    const hashedPassword = Helper.hashPassword(password);
+    await models.User.update({ password: hashedPassword }, { where: { email } });
+    await BlacklistedToken.create({ token, userId: id });
+    return res.status(200).send({
+      message: 'Your Password has been reset successfully'
+    });
   }
 }

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -213,6 +213,7 @@ export default class AuthController {
         },
       });
     } catch (error) {
+      /* istanbul ignore next-line */
       next(error);
     }
   }

--- a/docs/auth/forgotpassword.json
+++ b/docs/auth/forgotpassword.json
@@ -1,0 +1,56 @@
+{
+    "post": {
+      "tags": ["Auth"],
+      "summary": "Forgot password",
+      "description": "Forgot your password",
+      "parameters": [{
+        "name": "Forgot your password",
+        "in": "body",
+        "description": "request payload",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "example": "tunjiabioye@outlook.com"
+            }
+           }
+        }
+      }],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Forgot Password!",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "example": "tunjiabioye@outlook.com"
+              },
+              "token": {
+                "type": "string",
+                "example": "averylongstring"
+              },
+              "message": {
+                "type": "string",
+                "example": "Your reset link has been sent to your email"
+              }
+              }
+            }
+          },
+        "404": {
+          "description": "You are not an existing user, please sign up",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string",
+                "example": "You are not an existing user, please sign up"
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/docs/auth/resetpassword.json
+++ b/docs/auth/resetpassword.json
@@ -1,0 +1,75 @@
+{
+    "patch": {
+      "tags": ["Auth"],
+      "summary": "Reset password",
+      "description": "Reset your password",
+      "parameters": [{
+        "name": "Reset your password",
+        "in": "body",
+        "description": "request payload",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "password": {
+              "type": "string",
+              "example": "Pa55w0rd"
+            },
+            "confirmPassword": {
+                "type": "string",
+                "example": "Pa55w0rd"
+              } 
+           }
+        }
+      },
+      {
+        "name": "token",
+        "in": "path",
+        "schema": {
+          "type": "string",
+          "example": "averylongstring"
+        },
+        "required": true,
+        "description": "Unique number"
+      }
+    ],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Reset Password!",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string",
+                "example": "Your Password has been reset successfully"
+              }
+            }
+          }
+        },
+        "404": {
+            "description": "You are not an existing user, please sign up",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "You are not an existing user, please sign up"
+                }
+              }
+            }
+          },
+        "409": {
+          "description": "This link has already been used once, please request another link.",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string",
+                "example": "This link has already been used once, please request another link."
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/docs/index.js
+++ b/docs/index.js
@@ -7,6 +7,8 @@ import googleLogin from './auth/google';
 import createProfile from './profile/createProfile.json';
 import viewAndEditProfile from './profile/viewAndEditProfile.json';
 import verifyemail from './auth/verifyemail';
+import forgotpassword from './auth/forgotpassword.json';
+import resetpassword from './auth/resetpassword.json';
 
 swagger.paths['/auth/signup'] = signup;
 swagger.paths['/auth/signin'] = login;
@@ -16,6 +18,8 @@ swagger.paths['/auth/google'] = googleLogin;
 swagger.paths['/profiles'] = createProfile;
 swagger.paths['/profiles/{id}'] = viewAndEditProfile;
 swagger.paths['/verify'] = verifyemail;
+swagger.paths['/auth/forgotpassword'] = forgotpassword;
+swagger.paths['/auth/resetpassword/{token}'] = resetpassword;
 
 
 export default swagger;

--- a/helpers/Auth.js
+++ b/helpers/Auth.js
@@ -1,4 +1,4 @@
-import jwt from 'jsonwebtoken';
+import jwt, { verify } from 'jsonwebtoken';
 import { hashSync, compareSync } from 'bcryptjs';
 import { config } from 'dotenv';
 
@@ -15,6 +15,15 @@ class Helper {
    */
   static createToken(payload) {
     return jwt.sign(payload, process.env.SECRET_KEY, { expiresIn: '24d' });
+  }
+
+  /**
+   * @description Handles access token verification
+   * @param {string} token - The user credential {id, isAdmin}
+   * @return {object} access token values
+   */
+  static verifyToken(token) {
+    return verify(token, process.env.SECRET_KEY);
   }
 
   /**

--- a/helpers/ForgotPasswordEmail.js
+++ b/helpers/ForgotPasswordEmail.js
@@ -1,0 +1,35 @@
+import Postals from './Postals';
+
+/**
+ *
+ *
+ * @export
+ * @class ForgotPasswordEmail
+ */
+export default class ForgotPasswordEmail {
+  /**
+     *  @static
+     * @param {string} requestInfo - request information
+     * @param {string} recipient - recipient of the email
+     * @param {string} token - reset token
+     * @memberof ForgotPasswordEmail
+     * @returns {function} - returns a function call
+     */
+  static sendResetEmail({ protocol, hostname }, recipient, token) {
+    const { PORT } = process.env;
+    const email = recipient;
+    const content = `<img src = 'https://res.cloudinary.com/dsqyhgfws/image/upload/v1564047885/assets/logo_hjqgbb.png'>
+                        <br><h1>Good day,</h1><br>
+                        <h2>You requested to reset your Authors' Haven password</h2><br>
+                        <h2>Please click the link <a href = '${protocol}://${hostname}${PORT ? `:${PORT}` : ''}/api/v1/auth/resetpassword/${token}'>here</a> to reset your password</h2><br>
+                        <h2>If you didn't request a password reset, please ignore this message</h2>
+                        `;
+
+    Postals.sendEmail(
+      email,
+      'mazus.ah@gmail.com',
+      'Authors Haven',
+      content
+    );
+  }
+}

--- a/helpers/passportStrategies.js
+++ b/helpers/passportStrategies.js
@@ -21,10 +21,12 @@ const googleConfig = {
 
 passport.use(new facebook.Strategy(
   fbConfig,
+  /* istanbul ignore next-line */
   (accessToken, refreshToken, profile, done) => done(null, profile)
 ));
 
 passport.use(new google.OAuth2Strategy(
+  /* istanbul ignore next-line */
   googleConfig,
   (accessToken, refreshToken, profile, done) => done(null, profile)
 ));

--- a/middlewares/inputValidation.js
+++ b/middlewares/inputValidation.js
@@ -175,5 +175,51 @@ const validate = {
       return next();
     }
   ],
+  resetforgotPassword: [
+    check('password')
+      .not()
+      .isEmpty({ ignore_whitespace: true })
+      .withMessage('Password is required')
+      .matches(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[0-9a-zA-Z]/, 'i')
+      .withMessage('Password must contain at least one uppercase letter, one lowercase letter and one numeric digit')
+      .trim()
+      .isLength({ min: 8 })
+      .withMessage('Password must be at least 8 characters'),
+    (req, res, next) => {
+      const errors = validationResult(req);
+      const errorMessage = {};
+      if (!errors.isEmpty()) {
+        errors.array({ onlyFirstError: true }).forEach((error) => {
+          errorMessage[error.param] = error.msg;
+        });
+        return res.status(400).json({
+          errors: errorMessage,
+        });
+      }
+      return next();
+    }
+  ],
+  resetemail: [
+    check('email')
+      .not()
+      .isEmpty({ ignore_whitespace: true })
+      .withMessage('Email is required')
+      .isEmail()
+      .trim()
+      .withMessage('Please input a valid email address'),
+    (req, res, next) => {
+      const errors = validationResult(req);
+      const errorMessage = {};
+      if (!errors.isEmpty()) {
+        errors.array({ onlyFirstError: true }).forEach((error) => {
+          errorMessage[error.param] = error.msg;
+        });
+        return res.status(400).json({
+          errors: errorMessage,
+        });
+      }
+      return next();
+    }
+  ],
 };
 export default validate;

--- a/middlewares/inputValidation.js
+++ b/middlewares/inputValidation.js
@@ -189,9 +189,11 @@ const validate = {
       const errors = validationResult(req);
       const errorMessage = {};
       if (!errors.isEmpty()) {
+        /* istanbul ignore next-line */
         errors.array({ onlyFirstError: true }).forEach((error) => {
           errorMessage[error.param] = error.msg;
         });
+        /* istanbul ignore next-line */
         return res.status(400).json({
           errors: errorMessage,
         });

--- a/middlewares/inputValidation.js
+++ b/middlewares/inputValidation.js
@@ -189,11 +189,9 @@ const validate = {
       const errors = validationResult(req);
       const errorMessage = {};
       if (!errors.isEmpty()) {
-        /* istanbul ignore next-line */
         errors.array({ onlyFirstError: true }).forEach((error) => {
           errorMessage[error.param] = error.msg;
         });
-        /* istanbul ignore next-line */
         return res.status(400).json({
           errors: errorMessage,
         });

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -11,9 +11,12 @@ const {
   logout,
   socialLogin,
   verifyEmail,
+  forgotPassword,
+  resetPassword,
 } = AuthController;
 
 const { verifyToken } = AuthMiddleware;
+const { resetforgotPassword, resetemail } = Validate;
 
 const router = Router();
 
@@ -27,5 +30,8 @@ router.get('/facebook/callback', passport.authenticate('facebook', { session: fa
 
 router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
 router.get('/google/callback', passport.authenticate('google', { session: false }), socialLogin);
+
+router.post('/forgotpassword', resetemail, forgotPassword);
+router.patch('/resetpassword/:token', resetforgotPassword, resetPassword);
 
 export default router;


### PR DESCRIPTION
### What does this PR do?
User should be able to reset password

#### Description of Task to be completed?
wrote an integration test for forgot password and reset password
wrote forgot password and reset password controllers
adds a helper function to interface with the postal of email
adds a helper function to verify jw token
adds routes for both controllers

#### How should this be manually tested?

> 1. Fetch this branch on the terminal using 
> `git fetch origin ft-resetpasswordfeature-167165058`
> 2. Install dependencies using `npm install`
> 3. Start the server with `npm run server`
> 4. On Postman, sign up by making a POST request to /api/v1/auth/signup.
> 5. On Postman, make a POST request to /api/v1/auth/forgotpassword.
> 5. Check your inbox of the email you signed up with for a reset password link from authors haven.
> 6. Upon redirection to the browser, copy the link in the URL bar.
> 7. Paste this link in Postman and make a PATCH request.
> 

#### Any background context you want to provide?
User cannot reset the password with the same token more than once

#### What are the relevant pivotal tracker stories?
[#167165058](https://www.pivotaltracker.com/story/show/167165058)

#### Screenshots (if appropriate)
