### PR TITLE
#167165064 Implement Pagination For Article Ratings

### DIFF
--- a/database/seeders/20190724113532-demo-user.js
+++ b/database/seeders/20190724113532-demo-user.js
@@ -1,5 +1,6 @@
 /* eslint-disable arrow-body-style */
 /* eslint-disable no-unused-vars */
+import faker from 'faker';
 import Helper from '../../helpers/Auth';
 
 const password = Helper.hashPassword('passwordHash');
@@ -42,10 +43,90 @@ module.exports = {
           password: `${password}`,
         },
         {
-          id: '32fd7e50-b687-447f-af7c-c209b8f90041',
+          id: '588ae2cd-de3f-404a-87b3-8a6d50864833',
           firstName: 'Pelumi',
           lastName: 'Noah',
           email: 'pelumi@test.com',
+          password: Helper.hashPassword('PasswoRD123__'),
+          isVerified: true,
+        },
+        {
+          id: '356304da-50bc-4488-9c85-88874a9efb16',
+          firstName: faker.name.firstName(),
+          lastName: faker.name.lastName(),
+          email: faker.internet.email(),
+          password: Helper.hashPassword('PasswoRD123__'),
+          isVerified: true,
+        },
+        {
+          id: '51d509cc-b787-4abf-b176-fdb63cb9ed44',
+          firstName: faker.name.firstName(),
+          lastName: faker.name.lastName(),
+          email: faker.internet.email(),
+          password: Helper.hashPassword('PasswoRD123__'),
+          isVerified: true,
+        },
+        {
+          id: '1810e81d-9e5c-4a50-97e2-410fa230e166',
+          firstName: faker.name.firstName(),
+          lastName: faker.name.lastName(),
+          email: faker.internet.email(),
+          password: Helper.hashPassword('PasswoRD123__'),
+          isVerified: true,
+        },
+        {
+          id: 'c3ee24b4-46ea-4b96-bad9-a114a8baf7a8',
+          firstName: faker.name.firstName(),
+          lastName: faker.name.lastName(),
+          email: faker.internet.email(),
+          password: Helper.hashPassword('PasswoRD123__'),
+          isVerified: true,
+        },
+        {
+          id: 'a3868c24-6648-434c-8085-cf16ceb8915c',
+          firstName: faker.name.firstName(),
+          lastName: faker.name.lastName(),
+          email: faker.internet.email(),
+          password: Helper.hashPassword('PasswoRD123__'),
+          isVerified: true,
+        },
+        {
+          id: 'cf4aa1aa-7996-400e-a92d-b0ee07c91277',
+          firstName: faker.name.firstName(),
+          lastName: faker.name.lastName(),
+          email: faker.internet.email(),
+          password: Helper.hashPassword('PasswoRD123__'),
+
+        },
+        {
+          id: '24000aa6-8bb4-48a5-b65a-3ab8e91ddbed',
+          firstName: faker.name.firstName(),
+          lastName: faker.name.lastName(),
+          email: faker.internet.email(),
+          password: Helper.hashPassword('PasswoRD123__'),
+
+        },
+        {
+          id: 'dfd40601-af8a-4250-bb7c-1f01bb2de6d5',
+          firstName: faker.name.firstName(),
+          lastName: faker.name.lastName(),
+          email: faker.internet.email(),
+          password: Helper.hashPassword('PasswoRD123__'),
+
+        },
+        {
+          id: 'b604652c-4332-4633-9217-a1d921024b6a',
+          firstName: faker.name.firstName(),
+          lastName: faker.name.lastName(),
+          email: faker.internet.email(),
+          password: Helper.hashPassword('PasswoRD123__'),
+
+        },
+        {
+          id: '7c7a6097-2626-4136-b719-43f65977e021',
+          firstName: faker.name.firstName(),
+          lastName: faker.name.lastName(),
+          email: faker.internet.email(),
           password: Helper.hashPassword('PasswoRD123__'),
           isVerified: true,
         },

--- a/database/seeders/20190730121518-demo-ratings.js
+++ b/database/seeders/20190730121518-demo-ratings.js
@@ -1,5 +1,6 @@
 /* eslint-disable arrow-body-style */
 /* eslint-disable no-unused-vars */
+import uuidV4 from 'uuid/v4';
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
@@ -7,35 +8,90 @@ module.exports = {
       'Ratings',
       [
         {
-          id: '1536b14b-0669-42aa-a0a9-cae685aecc74',
+          id: uuidV4(),
           rate: 1,
-          userId: 'ffe25dbe-29ea-4759-8461-ed116f6739dd',
+          userId: '7c7a6097-2626-4136-b719-43f65977e021',
           articleId: 'ab8b9dc1-22bc-4dc2-b2dd-942a5dcbf03b',
         },
         {
-          id: '90356e2a-2f35-48e9-9add-9811c23f2122',
+          id: uuidV4(),
+          rate: 5,
+          userId: 'b604652c-4332-4633-9217-a1d921024b6a',
+          articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
+        },
+        {
+          id: uuidV4(),
+          rate: 5,
+          userId: 'dfd40601-af8a-4250-bb7c-1f01bb2de6d5',
+          articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
+        },
+        {
+          id: uuidV4(),
+          rate: 5,
+          userId: '24000aa6-8bb4-48a5-b65a-3ab8e91ddbed',
+          articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
+        },
+        {
+          id: uuidV4(),
+          rate: 2,
+          userId: 'cf4aa1aa-7996-400e-a92d-b0ee07c91277',
+          articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
+        },
+        {
+          id: uuidV4(),
+          rate: 1,
+          userId: 'c3ee24b4-46ea-4b96-bad9-a114a8baf7a8',
+          articleId: 'ab8b9dc1-22bc-4dc2-b2dd-942a5dcbf03b',
+        },
+        {
+          id: uuidV4(),
+          rate: 5,
+          userId: 'fdfe8617-208d-4b87-a000-5d6840786ab8',
+          articleId: 'cf67650f-2b74-416e-9050-89f92f147ecb',
+        },
+        {
+          id: uuidV4(),
+          rate: 5,
+          userId: '51d509cc-b787-4abf-b176-fdb63cb9ed44',
+          articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
+        },
+        {
+          id: uuidV4(),
+          rate: 5,
+          userId: '356304da-50bc-4488-9c85-88874a9efb16',
+          articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
+        },
+        {
+          id: uuidV4(),
+          rate: 2,
+          userId: '588ae2cd-de3f-404a-87b3-8a6d50864833',
+          articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
+        },
+        {
+          id: uuidV4(),
+          rate: 1,
+          userId: '90356e2a-2f35-48e9-9add-9811c23f2122',
+          articleId: 'ab8b9dc1-22bc-4dc2-b2dd-942a5dcbf03b',
+        },
+        {
+          id: uuidV4(),
           rate: 5,
           userId: 'fdfe8617-208d-4b87-a000-5d6840786ab8',
           articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
         },
         {
-          id: 'fdfe8617-208d-4b87-a000-5d6840786ab8',
+          id: uuidV4(),
           rate: 5,
-          userId: 'fdfe8617-208d-4b87-a000-5d6840786ab8',
+          userId: '8c9589fb-5b25-4df9-92ee-2b20ba4f9407',
           articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
         },
         {
-          id: '8c9589fb-5b25-4df9-92ee-2b20ba4f9407',
-          rate: 5,
-          userId: 'fdfe8617-208d-4b87-a000-5d6840786ab8',
-          articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
-        },
-        {
-          id: '35dc7202-c52a-4762-8637-6a92f6492c02',
+          id: uuidV4(),
           rate: 2,
           userId: 'ffe25dbe-29ea-4759-8461-ed116f6739dd',
           articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
         },
+
       ],
       {},
     );

--- a/docs/rating/rating.json
+++ b/docs/rating/rating.json
@@ -19,6 +19,20 @@
           "type": "integer"
         },
         "description": "The Article ID you want to check"
+      },
+      {
+        "name": "page",
+        "in": "query",
+        "description": "Enter page number",
+        "required": false,
+        "type": "integer"
+      },
+      {
+        "name": "pageSize",
+        "in": "query",
+        "description": "Enter page size",
+        "required": false,
+        "type": "integer"
       }
     ],
     "produces": [

--- a/helpers/Pagination.js
+++ b/helpers/Pagination.js
@@ -1,0 +1,27 @@
+/**
+ *
+ * @param {number} offset - offset number
+ *
+ * @param {number} limit - limit number
+ *
+ * @param {object} ratings
+ *
+ * @returns {object} pagination - with the limit and offset fields
+ * to query database
+ */
+
+const pagination = (page, pageLimit) => {
+  if (!page) {
+    page = 1;
+  }
+  if (!pageLimit) {
+    pageLimit = 10;
+  }
+  const offset = (page - 1) * pageLimit;
+  const limit = pageLimit;
+  return {
+    offset,
+    limit,
+  };
+};
+export default pagination;

--- a/modules/ServerResponse.js
+++ b/modules/ServerResponse.js
@@ -72,7 +72,7 @@ export default class ServerResponse {
    * @memberof ServerResponse
    */
   static serverErrorResponse(err, req, res, next) {
-  /* istanbul ignore next-line */
+    /* istanbul ignore next-line */
     return res.status(err.status || 500).json({
       errors: {
         message:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2960,6 +2960,11 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
       "helpers/ForgotPasswordEmail.js",
       "helpers/Postals.js",
       "helpers/passportStrategies.js",
+      "helpers/Pagination.js",
       "__tests__/*"
     ]
   },
@@ -44,6 +45,7 @@
     "express-jwt": "^5.3.1",
     "express-session": "^1.15.6",
     "express-validator": "^6.1.1",
+    "faker": "^4.1.0",
     "jsonwebtoken": "^8.3.0",
     "method-override": "^2.3.10",
     "methods": "^1.1.2",
@@ -58,7 +60,8 @@
     "sequelize": "^5.10.2",
     "sequelize-cli": "^5.5.0",
     "swagger-ui-express": "^4.0.7",
-    "underscore": "^1.9.1"
+    "underscore": "^1.9.1",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/routes/ratingRoutes.js
+++ b/routes/ratingRoutes.js
@@ -1,11 +1,9 @@
 import { Router } from 'express';
-import AuthMiddleware from '../middlewares/Authentication';
 import RatingController from '../controllers/RatingController';
 
-const { verifyToken } = AuthMiddleware;
 const { getArticleRatings } = RatingController;
 const router = Router();
 
-router.get('/:slug/ratings', verifyToken, getArticleRatings);
+router.get('/:slug/ratings', getArticleRatings);
 
 export default router;


### PR DESCRIPTION
### What does this PR do?
Adds functionality for pagination for article ratings
#### Description of Task to be completed?
Articles can be viewed in pages
#### How should this be manually tested?
> 1. Fetch this branch on the terminal using 
> `git fetch origin ft-paginate-article-ratings-167165064`
> 2. Install dependencies using `npm install`
> 3. Start the server with `npm run server`
> 4. On Postman, sign up by making a POST request to /api/v1/auth/signup.
> 5. On Postman, make a POST request to `/api/v1/articles/:slug/ratings`

#### Any background context you want to provide?
Pagination support is lacking for our ratings. 
Fetching all ratings at once as the content scales will affect the performance, so we need to pagination article's ratings.
#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)
<img width="1140" alt="Screenshot 2019-08-02 at 14 45 21" src="https://user-images.githubusercontent.com/28678648/62374684-62154a00-b534-11e9-9065-3bee5c7e294f.png">
<img width="1140" alt="Screenshot 2019-08-02 at 14 45 59" src="https://user-images.githubusercontent.com/28678648/62374696-693c5800-b534-11e9-8363-ef92b8d767ad.png">
<img width="1140" alt="Screenshot 2019-08-02 at 14 46 34" src="https://user-images.githubusercontent.com/28678648/62374716-72c5c000-b534-11e9-9804-1234252ea0f4.png">


