### PR TITLE
#167165077 Users should be able to like a specific comment

### DIFF
--- a/controllers/ArticleController.js
+++ b/controllers/ArticleController.js
@@ -97,7 +97,7 @@ export default class ArticleController {
           { // Article Comments
             model: models.Comment,
             as: 'articlecomment',
-            attributes: ['body', 'createdAt', 'updatedAt'],
+            attributes: ['body', 'likes', 'createdAt', 'updatedAt'],
             include: [
               { // user
                 model: models.User,
@@ -162,7 +162,7 @@ export default class ArticleController {
             { // Article Comments
               model: models.Comment,
               as: 'articlecomment',
-              attributes: ['body', 'createdAt', 'updatedAt'],
+              attributes: ['body', 'likes', 'createdAt', 'updatedAt'],
               include: [
                 { // user
                   model: models.User,
@@ -197,7 +197,7 @@ export default class ArticleController {
           { // Article Comments
             model: models.Comment,
             as: 'articlecomment',
-            attributes: ['body', 'createdAt', 'updatedAt'],
+            attributes: ['body', 'likes', 'createdAt', 'updatedAt'],
             include: [
               { // user
                 model: models.User,
@@ -257,7 +257,7 @@ export default class ArticleController {
           { // Article Comments
             model: models.Comment,
             as: 'articlecomment',
-            attributes: ['body', 'createdAt', 'updatedAt'],
+            attributes: ['body', 'likes', 'createdAt', 'updatedAt'],
             include: [
               { // user
                 model: models.User,
@@ -310,7 +310,7 @@ export default class ArticleController {
           { // Article Comments
             model: models.Comment,
             as: 'articlecomment',
-            attributes: ['body', 'createdAt', 'updatedAt'],
+            attributes: ['body', 'likes', 'createdAt', 'updatedAt'],
             include: [
               { // user
                 model: models.User,

--- a/controllers/CommentController.js
+++ b/controllers/CommentController.js
@@ -3,6 +3,8 @@ import ServerResponse from '../modules';
 import Notification from '../helpers/Notification';
 
 const { successResponse, notFoundError, errorResponse } = ServerResponse;
+const { Comment, Like } = models;
+
 /**
  * @class CommentController
  * @exports CommentController
@@ -40,6 +42,82 @@ export default class CommentController {
       return successResponse(res, 201, 'comment', articleComment.dataValues);
     } catch (error) {
       return next(error);
+    }
+  }
+
+
+  /**
+   * Method to like a single comment
+   *
+   * @static
+   * @param {object} req
+   * @param {object} res
+   * @param {function} next
+   * @returns {object} details of the liked comment
+   * @memberof CommentController
+   */
+  static async likeComment(req, res, next) {
+    try {
+      const { commentId } = req.params;
+      const { id } = req.user;
+
+      const foundComment = await Comment.findOne({
+        where: {
+          id: commentId,
+        }
+      });
+
+      if (!foundComment) {
+        return errorResponse(res, 404, { comment: 'That comment does not exist' });
+      }
+
+      const alreadyLiked = await Like.findOne({
+        where: {
+          commentId,
+          userId: id,
+        }
+      });
+
+      if (alreadyLiked) {
+        await Like.destroy({
+          where: {
+            commentId
+          }
+        });
+
+        await Comment.update(
+          {
+            likes: foundComment.dataValues.likes - 1,
+          },
+          {
+            where: {
+              id: foundComment.dataValues.id,
+            }
+          }
+        );
+
+        return successResponse(res, 200, 'comment', { message: '\'Like\' has been removed' });
+      }
+
+      const like = await Like.create({
+        commentId,
+        userId: id,
+        like: true,
+      });
+
+      await Comment.update(
+        {
+          likes: foundComment.dataValues.likes + 1,
+        },
+        {
+          where: {
+            id: foundComment.dataValues.id,
+          }
+        }
+      );
+      return successResponse(res, 201, 'comment', { message: 'Comment liked', like });
+    } catch (err) {
+      return next(err);
     }
   }
 }

--- a/database/migrations/20190723132825-create-comments.js
+++ b/database/migrations/20190723132825-create-comments.js
@@ -37,6 +37,10 @@ module.exports = {
       articleSlug: {
         type: Sequelize.STRING,
       },
+      likes: {
+        type: Sequelize.INTEGER,
+        defaultValue: 0,
+      },
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE,

--- a/database/models/comments.js
+++ b/database/models/comments.js
@@ -15,6 +15,10 @@ module.exports = (sequelize, DataTypes) => {
     articleSlug: {
       type: DataTypes.STRING,
     },
+    likes: {
+      type: DataTypes.INTEGER,
+      defaultValue: 0,
+    },
   }, {});
   Comment.associate = (models) => {
     Comment.hasMany(models.Like, {

--- a/database/models/like.js
+++ b/database/models/like.js
@@ -18,6 +18,11 @@ module.exports = (sequelize, DataTypes) => {
   }, {});
   Like.associate = (models) => {
     // associations can be defined here
+    Like.belongsTo(models.Comment, {
+      foreignKey: 'commentId',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    });
   };
   return Like;
 };

--- a/routes/commentRoutes.js
+++ b/routes/commentRoutes.js
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import CommentController from '../controllers/CommentController';
+import AuthMiddleware from '../middlewares/Authentication';
+
+const router = Router();
+const { likeComment } = CommentController;
+
+const { verifyToken, verifiedUserOnly } = AuthMiddleware;
+
+router.post('/likes/:commentId', verifyToken, verifiedUserOnly, likeComment);
+
+export default router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,6 +6,7 @@ import articleRoutes from './articleRoutes';
 import userRoutes from './userRoutes';
 import notificationRoutes from './notificationRoutes';
 import emailSubscriptionRoute from './emailSubscriptionRoute';
+import commentRoutes from './commentRoutes';
 
 const router = Router();
 
@@ -16,5 +17,6 @@ router.use('/articles', articleRoutes);
 router.use('/users', userRoutes);
 router.use('/notifications', notificationRoutes);
 router.use('/users', emailSubscriptionRoute);
+router.use('/comments', commentRoutes);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?

Adds functionality to like a single comment
Changes comment model to include likes
Changes the like model to include like boolean values

#### Description of Task to be completed?

Users should be able to like a specific comment by hitting the route `POST -> /api/v1/comments/likes/:commentId`

*Flowchart for API flow to like a comment*
![Like a Comment API Flowchart (3)](https://user-images.githubusercontent.com/42325628/62617078-f43c9a00-b908-11e9-83c6-7a42370166f4.jpeg)


#### How should this be manually tested?

After cloning this repo, `cd` into it and do the following:

```bash
# fetch this branch
$ git fetch origin  ft-like-a-comment-167165077

# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run server
```
Using postman, log in or register an account and hit the post route to create an article (user must be verified via the verification route in #28 
After getting the token, add it to the header and make a request to the route stated above


#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#167165077](https://www.pivotaltracker.com/story/show/167165077)

#### Screenshots (if appropriate)

*User successfully liked a comment*
<img width="1281" alt="Screenshot 2019-08-06 at 11 53 04" src="https://user-images.githubusercontent.com/42325628/62534641-82e5e400-b841-11e9-81eb-fdce6e448cab.png">

*User removed their like for an article*
<img width="1280" alt="Screenshot 2019-08-06 at 11 56 21" src="https://user-images.githubusercontent.com/42325628/62534675-97c27780-b841-11e9-96f5-ef7a6bc531f2.png">

