### PR TITLE
#167729028 Fix Single Article Find by Slug

### DIFF
--- a/__tests__/articleRoutes.test.js
+++ b/__tests__/articleRoutes.test.js
@@ -13,7 +13,6 @@ let validUserToken;
 let notArticleOwnerToken;
 let unverifiedUserToken;
 let articleSlug;
-let userId;
 const fakeUserId = 'f6b3facb-eb83-47f8-8c1c-05207e62ed30';
 
 describe('Article Routes Test', () => {
@@ -23,8 +22,7 @@ describe('Article Routes Test', () => {
       .post('/api/v1/auth/signin')
       .send(seededUsers[0])
       .end((err, res) => {
-        const { token, id } = res.body.user;
-        userId = id;
+        const { token } = res.body.user;
         validUserToken = token;
       });
 
@@ -33,8 +31,7 @@ describe('Article Routes Test', () => {
       .post('/api/v1/auth/signin')
       .send(seededUsers[2])
       .end((err, res) => {
-        const { token, id } = res.body.user;
-        userId = id;
+        const { token } = res.body.user;
         notArticleOwnerToken = token;
       });
 
@@ -193,7 +190,7 @@ describe('Article Routes Test', () => {
 
   it('should get an article by the slug', (done) => {
     chai.request(app)
-      .get(`${API_PREFIX}/${userId}/${articleSlug}`)
+      .get(`${API_PREFIX}/${articleSlug}`)
       .end((err, res) => {
         expect(res.status).to.be.eql(200);
         expect(res.body).to.have.property('article');
@@ -207,7 +204,7 @@ describe('Article Routes Test', () => {
 
   it('should return an error when trying to get articles for an author that doesn\'t exist', (done) => {
     chai.request(app)
-      .get(`${API_PREFIX}/${fakeUserId}/${articleSlug}`)
+      .get(`${API_PREFIX}/author/${fakeUserId}`)
       .end((err, res) => {
         expect(res.status).to.be.eql(404);
         expect(res.body).to.have.property('errors');
@@ -219,7 +216,7 @@ describe('Article Routes Test', () => {
 
   it('should return an error when trying to get articles for an author with an invalid id', (done) => {
     chai.request(app)
-      .get(`${API_PREFIX}/sillyId/${articleSlug}`)
+      .get(`${API_PREFIX}/author/sillyId`)
       .end((err, res) => {
         expect(res.status).to.be.eql(400);
         expect(res.body).to.have.property('errors');

--- a/controllers/ArticleController.js
+++ b/controllers/ArticleController.js
@@ -73,15 +73,9 @@ export default class ArticleController {
    *
    * @memberof ArticleController
    */
-  static async getArticlesArticleBySlug(req, res, next) {
+  static async getSingleArticleBySlug(req, res, next) {
     try {
-      const { slug, id } = req.params;
-      const findUser = await User.findOne({ where: { id } });
-
-      if (!findUser) {
-        return errorResponse(res, 404, { article: 'Author not found' });
-      }
-
+      const { slug } = req.params;
       const article = await Article.findOne({
         where: { slug, status: 'published' },
         include: [
@@ -108,7 +102,6 @@ export default class ArticleController {
           },
         ],
       });
-
       if (!article) {
         return errorResponse(res, 404, { article: 'Article not found' });
       }

--- a/routes/articleRoutes.js
+++ b/routes/articleRoutes.js
@@ -9,7 +9,7 @@ import Validate from '../middlewares/inputValidation';
 
 const {
   createArticle,
-  getArticlesArticleBySlug,
+  getSingleArticleBySlug,
   getAllArticles,
   getArticlesByAuthor,
   editArticle,
@@ -26,8 +26,8 @@ const router = Router();
 router.post('/:id/bookmark', verifyToken, Validate.validateParamsId, verifiedUserOnly, bookmarkArticle);
 
 router.post('/', verifyToken, verifiedUserOnly, articleValidation, createArticle);
-router.get('/:id/:slug', validateId, getArticlesArticleBySlug);
-router.get('/:id', validateId, getArticlesByAuthor);
+router.get('/:slug', getSingleArticleBySlug);
+router.get('/author/:id', validateId, getArticlesByAuthor);
 router.get('/', getAllArticles);
 router.patch('/:slug', verifyToken, verifiedUserOnly, articleValidation, editArticle);
 router.delete('/:slug', verifyToken, verifiedUserOnly, deleteArticle);


### PR DESCRIPTION
### What does this PR do?
fix single article find by slug route

#### Description of Task to be completed?
Refactor article controller to use only slug
Refactor tests to work with new url
Change get author's url to account for single article by slug

#### How should this be manually tested?
> 1. Fetch this branch on the terminal using 
> `git fetch origin bg-article-by-slug-167729028`
> 2. Install dependencies using `npm install`
> 3. Start the server with `npm run server`
> 4. On Postman, sign up by making a GET request to /api/v1/articles/:slug

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#167729028](https://www.pivotaltracker.com/story/show/167729028)

#### Screenshots (if appropriate)
<img width="1140" alt="Screenshot 2019-08-07 at 4 40 32 PM" src="https://user-images.githubusercontent.com/26358047/62639400-54e2cb80-b937-11e9-9ff3-9da015ee60da.png">
