### PR TITLE
#167808821 Correct status code for token verification

### DIFF
--- a/__tests__/articleRoutes.test.js
+++ b/__tests__/articleRoutes.test.js
@@ -99,7 +99,7 @@ describe('Article Routes Test', () => {
     chai.request(app)
       .post(`${API_PREFIX}`).send(mockArticles[3]).set('Authorization', 'Bearer faketokenvaluehere')
       .end((err, res) => {
-        expect(res.status).to.be.eql(403);
+        expect(res.status).to.be.eql(401);
         expect(res.body).to.have.property('errors');
         expect(res.body.errors).to.be.to.a('object');
         expect(res.body.errors).to.have.property('message').eql('Invalid token provided');

--- a/__tests__/authRoutes.test.js
+++ b/__tests__/authRoutes.test.js
@@ -142,7 +142,7 @@ describe('Auth Routes Test', () => {
       .post(`${API_PREFIX}/logout`)
       .set('Authorization', `Bearer ${blacklistedToken}`)
       .end((err, res) => {
-        expect(res.status).to.eql(403);
+        expect(res.status).to.eql(401);
         expect(res.body)
           .to.have.property('errors')
           .to.be.a('object');

--- a/__tests__/emailSubscription.test.js
+++ b/__tests__/emailSubscription.test.js
@@ -74,7 +74,7 @@ describe('Subscribing to email notifications', () => {
       .patch(`${url}/users/emailNotify`)
       .set('Authorization', `Bearer ${blacklistedToken}`)
       .end((err, res) => {
-        expect(res.status).to.eql(403);
+        expect(res.status).to.eql(401);
         expect(res.body.errors.message).to.eql('Invalid token provided, please sign in');
         done();
       });
@@ -84,7 +84,7 @@ describe('Subscribing to email notifications', () => {
       .patch(`${url}/users/emailNotify`)
       .set('Authorization', `Bearer ${secondUserToken}s`)
       .end((err, res) => {
-        expect(res.status).to.eql(403);
+        expect(res.status).to.eql(401);
         expect(res.body.errors.message).to.eql('Invalid token provided');
         done();
       });

--- a/__tests__/notification.test.js
+++ b/__tests__/notification.test.js
@@ -71,7 +71,7 @@ describe('Fetching user notifications', () => {
       .get(`${url}/notifications`)
       .set('Authorization', `Bearer ${blacklistedToken}`)
       .end((err, res) => {
-        expect(res.status).to.eql(403);
+        expect(res.status).to.eql(401);
         expect(res.body.errors.message).to.eql('Invalid token provided, please sign in');
         done();
       });
@@ -81,7 +81,7 @@ describe('Fetching user notifications', () => {
       .get(`${url}/notifications`)
       .set('Authorization', `Bearer ${firstUserToken}s`)
       .end((err, res) => {
-        expect(res.status).to.eql(403);
+        expect(res.status).to.eql(401);
         expect(res.body.errors.message).to.eql('Invalid token provided');
         done();
       });
@@ -176,7 +176,7 @@ describe('Marking a user notification as read', () => {
       .patch(`${url}/notifications/${notificationId}`)
       .set('Authorization', `Bearer ${blacklistedToken}`)
       .end((err, res) => {
-        expect(res.status).to.eql(403);
+        expect(res.status).to.eql(401);
         expect(res.body.errors.message).to.eql('Invalid token provided, please sign in');
         done();
       });
@@ -186,7 +186,7 @@ describe('Marking a user notification as read', () => {
       .patch(`${url}/notifications/${notificationId}`)
       .set('Authorization', `Bearer ${firstUserToken}s`)
       .end((err, res) => {
-        expect(res.status).to.eql(403);
+        expect(res.status).to.eql(401);
         expect(res.body.errors.message).to.eql('Invalid token provided');
         done();
       });

--- a/__tests__/statisticsRoutes.test.js
+++ b/__tests__/statisticsRoutes.test.js
@@ -52,7 +52,7 @@ describe('Reading statistics for articles published by an author', () => {
       .get(`${url}/statistics/published`)
       .set('Authorization', `Bearer ${userToken}s`)
       .end((err, res) => {
-        expect(res.status).to.eql(403);
+        expect(res.status).to.eql(401);
         expect(res.body.errors.message).to.eql('Invalid token provided');
         done();
       });
@@ -82,7 +82,7 @@ describe('Reading statistics for articles published by an author', () => {
       .get(`${url}/statistics/published`)
       .set('Authorization', `Bearer ${blacklistedToken}`)
       .end((err, res) => {
-        expect(res.status).to.eql(403);
+        expect(res.status).to.eql(401);
         expect(res.body.errors.message).to.eql('Invalid token provided, please sign in');
         done();
       });
@@ -136,7 +136,7 @@ describe('Reading statistics for articles an author or user has read', () => {
       .get(`${url}/statistics/read`)
       .set('Authorization', `Bearer ${userToken}s`)
       .end((err, res) => {
-        expect(res.status).to.eql(403);
+        expect(res.status).to.eql(401);
         expect(res.body.errors.message).to.eql('Invalid token provided');
         done();
       });
@@ -166,7 +166,7 @@ describe('Reading statistics for articles an author or user has read', () => {
       .get(`${url}/statistics/read`)
       .set('Authorization', `Bearer ${blacklistedToken}`)
       .end((err, res) => {
-        expect(res.status).to.eql(403);
+        expect(res.status).to.eql(401);
         expect(res.body.errors.message).to.eql('Invalid token provided, please sign in');
         done();
       });

--- a/controllers/ProfileController.js
+++ b/controllers/ProfileController.js
@@ -4,6 +4,8 @@ import ServerResponse from '../modules';
 const {
   User,
   Profile,
+  Reading,
+  Article,
 } = models;
 const { successResponse, errorResponse } = ServerResponse;
 /**
@@ -143,7 +145,7 @@ export default class ProfileController {
   static async articlesUserRead(req, res, next) {
     const userId = req.user.id;
     try {
-      const getStatistics = await models.Reading.findAll({ raw: true, where: { userId } });
+      const getStatistics = await Reading.findAll({ raw: true, where: { userId } });
       return successResponse(res, 200, 'articlesRead', getStatistics.length);
     } catch (error) {
       return next(error);
@@ -160,7 +162,7 @@ export default class ProfileController {
   static async articlesReadCount(req, res, next) {
     const userId = req.user.id;
     try {
-      const authorArticlesDetails = await models.Article.findAll({
+      const authorArticlesDetails = await Article.findAll({
         raw: true,
         where: { userId },
         attributes: ['title', 'id', 'readCount', 'slug', 'userId']

--- a/middlewares/Authentication.js
+++ b/middlewares/Authentication.js
@@ -44,14 +44,14 @@ export default class Authentication {
       });
 
       if (blacklistedToken) {
-        return errorResponse(res, 403, {
+        return errorResponse(res, 401, {
           message: 'Invalid token provided, please sign in',
         });
       }
 
       jwt.verify(token, SECRET_KEY, (err, decoded) => {
         if (err) {
-          return errorResponse(res, 403, {
+          return errorResponse(res, 401, {
             message: 'Invalid token provided',
           });
         }


### PR DESCRIPTION
#### What does this PR do?
Change status code for invalid and blacklisted token to 401 in test files and Authentication js file

#### Description of Task to be completed?
Endpoints that require a token should return 401 when an invalid token or a blacklisted token is provided.

#### How should this be manually tested?
1. Fetch this branch on the terminal using
git fetch origin ch-correct-status-code-for-token-verification-#167808821
2. Install dependencies using npm install
3. Start the server with npm run server
4. Launch Postman, sign in and try to access a protected route such as /api/v1/statistics/published
5. Supply an invalid token or a blacklisted token and expect a 401 status code.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#167808821](https://www.pivotaltracker.com/story/show/167808821)

#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2019-08-09 at 3 25 55 PM" src="https://user-images.githubusercontent.com/41482184/62786320-3eb14880-baba-11e9-9411-0a96c0864ac1.png">
<img width="1440" alt="Screen Shot 2019-08-09 at 3 27 27 PM" src="https://user-images.githubusercontent.com/41482184/62786340-48d34700-baba-11e9-8c6b-6bc055342561.png">
