### PR TITLE
#167806860 User can edit comment

### DIFF
--- a/__tests__/editComment.test.js
+++ b/__tests__/editComment.test.js
@@ -1,0 +1,158 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import app from '..';
+import models from '../database/models';
+
+
+chai.use(chaiHttp);
+const url = '/api/v1';
+const { expect } = chai;
+const { Comment } = models;
+const blacklistedToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoiSm9obiIsImlhdCI6MTU2NDAwOTA5NCwiZXhwIjoxNTY0MDEyNjk0fQ.J5ktoXlmLxOtV8R16sNPMXXeydwRdCA8h6Cep-AzZnc';
+const commentId = '6675f038-8c66-4485-9dcf-4660ac27ccd9';
+
+describe('Testing edit comment endpoint', () => {
+  let firstUserToken;
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signin')
+      .send({ email: 'fatima.kamali@outlook.com', password: 'P455w0rd' })
+      .end((err, res) => {
+        firstUserToken = res.body.user.token;
+        done();
+      });
+  });
+  let secondUserToken;
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signin')
+      .send({ email: 'sophie.kamali@outlook.com', password: 'P455w0rd' })
+      .end((err, res) => {
+        secondUserToken = res.body.user.token;
+        done();
+      });
+  });
+  let thirdUserToken;
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signin')
+      .send({ email: 'john.kamali@outlook.com', password: 'P455w0rd' })
+      .end((err, res) => {
+        thirdUserToken = res.body.user.token;
+        done();
+      });
+  });
+  it('should return an error response if the user is unverified', (done) => {
+    chai.request(app)
+      .patch(`${url}/comments/${commentId}`)
+      .set('Authorization', `Bearer ${secondUserToken}`)
+      .send({ body: 'This is brilliant' })
+      .end((err, res) => {
+        expect(res.status).to.eql(401);
+        expect(res.body.errors.message).to.eql('Your account has not been verified, please verify to continue');
+        done();
+      });
+  });
+  it('should return an error response if token is unavailable', (done) => {
+    chai.request(app)
+      .patch(`${url}/comments/${commentId}`)
+      .set('Authorization', '')
+      .send({ body: 'This is brilliant' })
+      .end((err, res) => {
+        expect(res.status).to.eql(401);
+        expect(res.body.errors.message).to.eql('No token provided');
+        done();
+      });
+  });
+  it('should return an error response if token is in the blacklist', (done) => {
+    chai.request(app)
+      .patch(`${url}/comments/${commentId}`)
+      .set('Authorization', `Bearer ${blacklistedToken}`)
+      .send({ body: 'This is brilliant' })
+      .end((err, res) => {
+        expect(res.status).to.eql(401);
+        expect(res.body.errors.message).to.eql('Invalid token provided, please sign in');
+        done();
+      });
+  });
+  it('should return an error response if token is invalid', (done) => {
+    chai.request(app)
+      .patch(`${url}/comments/${commentId}`)
+      .set('Authorization', `Bearer ${firstUserToken}s`)
+      .send({ body: 'This is brilliant' })
+      .end((err, res) => {
+        expect(res.status).to.eql(401);
+        expect(res.body.errors.message).to.eql('Invalid token provided');
+        done();
+      });
+  });
+  it('should return an error response for an empty comment', (done) => {
+    chai
+      .request(app)
+      .patch(`${url}/comments/${commentId}`)
+      .set('Authorization', `Bearer ${firstUserToken}`)
+      .send({ body: '' })
+      .end((err, res) => {
+        expect(res.status).to.eql(400);
+        expect(res.body).to.have.property('errors');
+        expect(res.body.errors.body).to.eql('comment body is required');
+        done();
+      });
+  });
+  it('should return an error response when a user tries to edit another user\'s comment', (done) => {
+    chai
+      .request(app)
+      .patch(`${url}/comments/${commentId}`)
+      .set('Authorization', `Bearer ${thirdUserToken}`)
+      .send({ body: 'Stop that' })
+      .end((err, res) => {
+        expect(res.status).to.eql(403);
+        expect(res.body).to.have.property('errors');
+        expect(res.body.errors).to.eql('You are not allowed to edit another user\'s comment');
+        done();
+      });
+  });
+  it('should return an error response when a user attempts to edit a non existing comment', (done) => {
+    chai
+      .request(app)
+      .patch(`${url}/comments/7675f038-8c66-4485-9dcf-4660ac27ccd9`)
+      .set('Authorization', `Bearer ${firstUserToken}`)
+      .send({ body: 'This is brilliant' })
+      .end((err, res) => {
+        expect(res.status).to.eql(404);
+        expect(res.body).to.have.property('errors');
+        expect(res.body.errors).to.eql('That comment does not exist');
+        done();
+      });
+  });
+  it('should return a success response when a comment has been edited', (done) => {
+    chai
+      .request(app)
+      .patch(`${url}/comments/${commentId}`)
+      .set('Authorization', `Bearer ${firstUserToken}`)
+      .send({ body: 'This is brilliant' })
+      .end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body).to.have.property('comment');
+        expect(res.body.comment.id).to.eql('6675f038-8c66-4485-9dcf-4660ac27ccd9');
+        expect(res.body.comment.userId).to.eql('6675f038-8c66-4485-9dcf-4660ac27ccd1');
+        expect(res.body.comment.articleId).to.eql('a2cda7e8-28ba-4507-9563-3e4ea280efb6');
+        expect(res.body.comment.body).to.eql('This is brilliant');
+        done();
+      });
+  });
+  it('should throw a server error', (done) => {
+    const stub = sinon.stub(Comment, 'update');
+    const error = new Error('Something went wrong');
+    stub.yields(error);
+    chai.request(app)
+      .patch(`${url}/comments/${commentId}`)
+      .set('Authorization', `Bearer ${firstUserToken}`)
+      .send({ body: 'This is brilliant' })
+      .end((err, res) => {
+        expect(res.status).to.eql(500);
+        done();
+      });
+  });
+});

--- a/controllers/CommentController.js
+++ b/controllers/CommentController.js
@@ -137,4 +137,41 @@ export default class CommentController {
       return next(err);
     }
   }
+
+  /**
+   * Method to edit a comment
+   *
+   * @static
+   * @param {object} req
+   * @param {object} res
+   * @param {function} next
+   * @returns {object} details of the edited comment
+   * @memberof CommentController
+   */
+  static async editComment(req, res, next) {
+    try {
+      const { id } = req.user;
+      const { commentId } = req.params;
+      const { body } = req.body;
+      const comment = await Comment.findOne({ where: { id: commentId } });
+      if (!comment) {
+        return errorResponse(res, 404, 'That comment does not exist');
+      }
+      if (comment.dataValues.userId !== id) {
+        return errorResponse(res, 403, 'You are not allowed to edit another user\'s comment');
+      }
+      const editedComment = await Comment.update(
+        {
+          body
+        },
+        {
+          where: { id: commentId },
+          returning: true
+        }
+      );
+      return successResponse(res, 200, 'comment', editedComment[1][0]);
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/database/seeders/20190724120159-demo-comments.js
+++ b/database/seeders/20190724120159-demo-comments.js
@@ -23,6 +23,12 @@ module.exports = {
           userId: 'ffe25dbe-29ea-4759-8461-ed116f6739dd',
           articleId: '3eab3b9c-9782-4cc8-95c4-31c3fe5df09e',
         },
+        {
+          id: '6675f038-8c66-4485-9dcf-4660ac27ccd9',
+          body: 'Nice one',
+          userId: '6675f038-8c66-4485-9dcf-4660ac27ccd1',
+          articleId: 'a2cda7e8-28ba-4507-9563-3e4ea280efb6',
+        },
       ],
       {},
     );

--- a/docs/comments/editComment.json
+++ b/docs/comments/editComment.json
@@ -1,0 +1,104 @@
+{
+    "patch": {
+      "security": [
+        {
+            "Bearer": []
+        }
+      ],
+      "tags": ["Comments"],
+      "summary": "Edit comment on an article",
+      "description": "Edit comment on an article",
+      "parameters": [
+        {
+          "name": "commentId",
+          "in": "path",
+          "required": true,
+          "description": "id of the comment",
+          "schema": {
+            "type": "string",
+            "example": "6675f038-8c66-4485-9dcf-4660ac27ccd9"
+          }
+        },
+        {
+            "name": "body",
+            "in": "body",
+            "required": "true",
+            "description": "body of the comment",
+            "schema": {
+                "type": "string",
+                "example": "nice one"
+            }
+        }
+      ],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "editedComment",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "6675f038-8c66-4485-9dcf-4660ac27ccd9"
+              },
+              "body": {
+                  "type": "string",
+                  "example": "Good job"
+              },
+              "userId": {
+                  "type": "string",
+                  "example": "6675f038-8c76-4485-9dcf-4660ac27dcd9"
+              },
+              "articleId": {
+                "type": "string",
+                "example": "6675f038-8c76-4485-9dcf-2360ac27dcd9"
+              },
+              "articleSlug": {
+                "type": "string",
+                "example": "John-Kamali-6675f038"
+              },
+              "createdAt": {
+                "type": "date",
+                "example": "2019-07-30T14:00:23.458Z"
+              },
+              "updatedAt": {
+                "type": "date",
+                "updatedAt": "2019-07-30T23:22:33.439Z"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Comment not found",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "errors": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "Comment not found"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Route accessed without token",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "errors": {
+                "type": "object",
+                "properties": {
+                  "message": { "type": "string", "example": "No token provided" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/docs/index.js
+++ b/docs/index.js
@@ -35,6 +35,7 @@ import myReadCount from './statistics/myReadCount.json';
 import reportArticle from './articles/reportArticle.json';
 import createUser from './admin/createUser.json';
 import updateDeleteUser from './admin/updateDeleteUser.json';
+import editComment from './comments/editComment.json';
 
 import getReportedArticles from './articles/getReportedArticles.json';
 import likeComment from './comments/likeComment.json';
@@ -77,6 +78,7 @@ swagger.paths['/statistics/read'] = myReadCount;
 
 swagger.paths['/admin/users'] = createUser;
 swagger.paths['/admin/users/{id}'] = updateDeleteUser;
+swagger.paths['/comments/{commentId}'] = editComment;
 
 swagger.paths['/comments/likes/{commentId}'] = likeComment;
 

--- a/routes/commentRoutes.js
+++ b/routes/commentRoutes.js
@@ -1,12 +1,13 @@
 import { Router } from 'express';
 import CommentController from '../controllers/CommentController';
 import AuthMiddleware from '../middlewares/Authentication';
+import commentValidate from '../middlewares/commentValidations';
 
 const router = Router();
-const { likeComment } = CommentController;
-
+const { likeComment, editComment } = CommentController;
 const { verifyToken, verifiedUserOnly } = AuthMiddleware;
 
 router.post('/likes/:commentId', verifyToken, verifiedUserOnly, likeComment);
+router.patch('/:commentId', verifyToken, verifiedUserOnly, commentValidate.comment, editComment);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
User can edit their own comment on article

#### Description of Task to be completed?
Has /api/v1/comments/${commentId} working
Add swagger documentation

![API Flowchart for edit comment (1)](https://user-images.githubusercontent.com/41482184/63028695-3f295500-bea7-11e9-9222-6cc00b97f7de.jpeg)




#### How should this be manually tested?
1. Fetch this branch on the terminal using 
git fetch origin ft-edit-comment-167806860
2. Install dependencies using npm install
3. Start the server with npm run server
4. On Postman, sign in as a verified user by making a POST request to /api/v1/auth/signin and use the token received for the request in the next step.
5. Call /api/v1/comments/${commentId} 

#### Note
You can only edit your own existing comment. Also ensure you enter a valid input in the body of the request

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#167806860](https://www.pivotaltracker.com/story/show/167806860)

#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2019-08-12 at 6 24 30 PM" src="https://user-images.githubusercontent.com/41482184/62887628-87c10100-bd35-11e9-8581-7d8acbbf5459.png">

