### PR TITLE
#167894243 Deleted articles should not go to trash

### DIFF
--- a/__tests__/articleRoutes.test.js
+++ b/__tests__/articleRoutes.test.js
@@ -282,21 +282,7 @@ describe('Article Routes Test', () => {
       });
   });
 
-  it('should send a published article to the trash can when it\'s deleted', (done) => {
-    chai.request(app)
-      .delete(`${API_PREFIX}/${seededArticles[0].slug}`)
-      .set('Authorization', `Bearer ${validUserToken}`)
-      .end((err, res) => {
-        expect(res.status).to.be.eql(200);
-        expect(res.body).to.have.property('article');
-        expect(res.body.article).to.be.to.a('object');
-        expect(res.body.article).to.have.property('message');
-        expect(res.body.article.message).to.eql('Article has been moved to your trash');
-        done();
-      });
-  });
-
-  it('should delete an article permanently, when it\'s already in the drafts', (done) => {
+  it('should delete an article', (done) => {
     chai.request(app)
       .delete(`${API_PREFIX}/${seededArticles[0].slug}`)
       .set('Authorization', `Bearer ${validUserToken}`)
@@ -309,6 +295,7 @@ describe('Article Routes Test', () => {
         done();
       });
   });
+
   it('should not bookmark if article id does not exist', (done) => {
     chai.request(app)
       .post(`${API_PREFIX}/cf67650f-5b74-416e-9050-89f92f147ecb/bookmark`)

--- a/controllers/ArticleController.js
+++ b/controllers/ArticleController.js
@@ -415,25 +415,6 @@ export default class ArticleController {
         return errorResponse(res, 404, { article: 'Article not found' });
       }
 
-      const { status } = foundArticle;
-
-      if (status === 'published' || status === 'draft') {
-        await Article.update(
-          {
-            status: 'trash'
-          },
-          {
-            where: {
-              slug,
-              userId: id
-            },
-            returning: true
-          }
-        );
-
-        return successResponse(res, 200, 'article', { message: 'Article has been moved to your trash' });
-      }
-
       await Article.destroy({
         where: {
           slug,


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where a deleted article goes to the trash

#### Description of Task to be completed?
Whenever an author deletes an article via the route; `DELETE /api/v1/articles/:slug`, then that article should be deleted outrightly

#### How should this be manually tested?
After cloning this repo, `cd` into it and do the following:

```bash
# fetch this branch
$ git fetch origin  bg-fix-deleted-articles-167894243

# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run server
```
Using postman, log in or register an account and hit the post route to create an article (user must be verified via the verification route in #28 
After getting the token, add it to the header and make a request to the route stated above


#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#167894243](https://www.pivotaltracker.com/story/show/167894243)

#### Screenshots (if appropriate)
<img width="1536" alt="Screenshot 2019-08-14 at 13 16 29" src="https://user-images.githubusercontent.com/42325628/63020344-cc63ae00-be95-11e9-97af-d2e6a647cdde.png">
