### PR TITLE
#167165082 Implements Get  Comment Edit History

### DIFF
--- a/__tests__/editComment.test.js
+++ b/__tests__/editComment.test.js
@@ -122,7 +122,7 @@ describe('Testing edit comment endpoint', () => {
       .end((err, res) => {
         expect(res.status).to.eql(404);
         expect(res.body).to.have.property('errors');
-        expect(res.body.errors).to.eql('That comment does not exist');
+        expect(res.body.errors.message).to.eql('Comment does not exist');
         done();
       });
   });

--- a/__tests__/getCommentHistory.test.js
+++ b/__tests__/getCommentHistory.test.js
@@ -1,0 +1,71 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import jwtDecode from 'jwt-decode';
+import app from '..';
+
+chai.use(chaiHttp);
+const url = '/api/v1/admin/comments';
+const { expect } = chai;
+const commentId = '6675f038-8c66-4485-9dcf-4660ac27ccd9';
+
+describe('Testting get comment edit history', () => {
+  let authorisedToken;
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signin')
+      .send({ email: 'jamal.sabri@mail.com', password: 'P455w0rd' })
+      .end((err, res) => {
+        authorisedToken = res.body.user.token;
+        done();
+      });
+  });
+
+  let unauthorisedUserToken;
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signin')
+      .send({ email: 'fatima.kamali@outlook.com', password: 'P455w0rd' })
+      .end((err, res) => {
+        unauthorisedUserToken = res.body.user.token;
+        done();
+      });
+  });
+
+  it('should return an error response if the comment edit history does not exist', (done) => {
+    chai.request(app)
+      .get(`${url}/b763843a-f223-48f4-99ec-8b6b1e4f179f`)
+      .set('Authorization', `Bearer ${authorisedToken}`)
+      .end((err, res) => {
+        expect(res.status).to.eql(200);
+        done();
+      });
+  });
+  it('should get all comment edit history for a comment', (done) => {
+    chai.request(app)
+      .get(`${url}/${commentId}`)
+      .set('Authorization', `Bearer ${authorisedToken}`)
+      .end((err, res) => {
+        const decoded = jwtDecode(authorisedToken);
+        expect(res.status).to.eql(200);
+        expect(res.body).to.be.to.a('object');
+        expect(decoded.type).to.eql('super-admin');
+        expect(res.body).to.have.property('commentHistory');
+        done();
+      });
+  });
+  it('should return an error response when a user tries to view comment history', (done) => {
+    chai
+      .request(app)
+      .get(`${url}/${commentId}`)
+      .set('Authorization', `Bearer ${unauthorisedUserToken}`)
+      .send({ body: 'Stop that' })
+      .end((err, res) => {
+        const decoded = jwtDecode(unauthorisedUserToken);
+        expect(res.status).to.eql(403);
+        expect(res.body).to.have.property('errors');
+        expect(decoded.type).to.eql('user');
+        expect(res.body.errors.message).to.eql('User not authorized');
+        done();
+      });
+  });
+});

--- a/database/migrations/20190814083130-create-comment-history.js
+++ b/database/migrations/20190814083130-create-comment-history.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-unused-vars */
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.sequelize.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
+    .then(() => queryInterface.createTable('CommentHistories', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.DataTypes.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+      },
+      commentId: {
+        type: Sequelize.DataTypes.UUID,
+        allowNull: false,
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        references: {
+          model: 'Comments',
+          key: 'id',
+        },
+      },
+      userId: {
+        type: Sequelize.DataTypes.UUID,
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        references: {
+          model: 'Users',
+          key: 'id',
+        },
+      },
+      oldComment: {
+        type: Sequelize.TEXT,
+        required: true,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    })),
+  down: (queryInterface, Sequelize) => queryInterface.dropTable('CommentHistories')
+};

--- a/database/models/commenthistory.js
+++ b/database/models/commenthistory.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-unused-vars */
+
+module.exports = (sequelize, DataTypes) => {
+  const CommentHistory = sequelize.define('CommentHistory', {
+    commentId: {
+      allowNull: false,
+      type: DataTypes.UUID,
+    },
+    userId: {
+      allowNull: false,
+      type: DataTypes.UUID,
+    },
+    oldComment: {
+      allowNull: false,
+      type: DataTypes.TEXT,
+    }
+  }, {});
+  CommentHistory.associate = (models) => {
+    CommentHistory.belongsTo(models.Comment, {
+      foreignKey: 'commentId',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    });
+    CommentHistory.belongsTo(models.User, {
+      foreignKey: 'userId',
+      as: 'user'
+    });
+  };
+  return CommentHistory;
+};

--- a/docs/admin/getCommentHistory.json
+++ b/docs/admin/getCommentHistory.json
@@ -1,0 +1,111 @@
+{
+  "get": {
+    "security": [
+      {
+        "Bearer": []
+      }
+    ],
+    "tags": [
+      "Admin"
+    ],
+    "summary": "Get previous versions of a comment",
+    "description": "Get previous versions of a comment",
+    "parameters": [
+      {
+        "name": "commentId",
+        "in": "path",
+        "required": true,
+        "description": "id of the comment",
+        "schema": {
+          "type": "string",
+          "example": "6675f038-8c66-4485-9dcf-4660ac27ccd9"
+        }
+      }
+    ],
+    "produces": [
+      "application/json"
+    ],
+    "responses": {
+      "200": {
+        "description": "commentHistory",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "commentHistory": {
+              "type": "array",
+              "example": [
+                {
+                  "id": "162271f4-4191-412d-b833-38339160fe80",
+                  "commentId": "35dc7202-c52a-4762-8637-6a92f6492c02",
+                  "userId": "ffe25dbe-29ea-4759-8461-ed116f6739dd",
+                  "oldComment": "helelejne",
+                  "createdAt": "2019-08-15T10:54:37.794Z",
+                  "updatedAt": "2019-08-15T10:54:37.794Z"
+                },
+                {
+                  "id": "372ed37c-2dc0-4d4a-8c11-5213346860ca",
+                  "commentId": "35dc7202-c52a-4762-8637-6a92f6492c02",
+                  "userId": "ffe25dbe-29ea-4759-8461-ed116f6739dd",
+                  "oldComment": "this article is quite interesting",
+                  "createdAt": "2019-08-15T10:53:51.084Z",
+                  "updatedAt": "2019-08-15T10:53:51.084Z"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "404": {
+        "description": "Comment not found",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "errors": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Comment not found"
+                }
+              }
+            }
+          }
+        }
+      },
+      "401": {
+        "description": "Route accessed without token",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "errors": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "No token provided"
+                }
+              }
+            }
+          }
+        }
+      },
+      "403": {
+        "description": "User not authorised",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "errors": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "User not authorised to view comment history"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/comments/editComment.json
+++ b/docs/comments/editComment.json
@@ -1,99 +1,192 @@
 {
-    "patch": {
-      "security": [
-        {
-            "Bearer": []
+  "patch": {
+    "security": [
+      {
+        "Bearer": []
+      }
+    ],
+    "tags": [
+      "Comments"
+    ],
+    "summary": "Edit comment on an article",
+    "description": "Edit comment on an article",
+    "parameters": [
+      {
+        "name": "commentId",
+        "in": "path",
+        "required": true,
+        "description": "id of the comment",
+        "schema": {
+          "type": "string",
+          "example": "6675f038-8c66-4485-9dcf-4660ac27ccd9"
         }
-      ],
-      "tags": ["Comments"],
-      "summary": "Edit comment on an article",
-      "description": "Edit comment on an article",
-      "parameters": [
-        {
-          "name": "commentId",
-          "in": "path",
-          "required": true,
-          "description": "id of the comment",
-          "schema": {
-            "type": "string",
-            "example": "6675f038-8c66-4485-9dcf-4660ac27ccd9"
-          }
-        },
-        {
-            "name": "body",
-            "in": "body",
-            "required": "true",
-            "description": "body of the comment",
-            "schema": {
-                "type": "string",
-                "example": "nice one"
-            }
+      },
+      {
+        "name": "body",
+        "in": "body",
+        "required": "true",
+        "description": "body of the comment",
+        "schema": {
+          "type": "string",
+          "example": "nice one"
         }
-      ],
-      "produces": ["application/json"],
-      "responses": {
-        "200": {
-          "description": "editedComment",
-          "schema": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "example": "6675f038-8c66-4485-9dcf-4660ac27ccd9"
-              },
-              "body": {
-                  "type": "string",
-                  "example": "Good job"
-              },
-              "userId": {
-                  "type": "string",
-                  "example": "6675f038-8c76-4485-9dcf-4660ac27dcd9"
-              },
-              "articleId": {
-                "type": "string",
-                "example": "6675f038-8c76-4485-9dcf-2360ac27dcd9"
-              },
-              "articleSlug": {
-                "type": "string",
-                "example": "John-Kamali-6675f038"
-              },
-              "createdAt": {
-                "type": "date",
-                "example": "2019-07-30T14:00:23.458Z"
-              },
-              "updatedAt": {
-                "type": "date",
-                "updatedAt": "2019-07-30T23:22:33.439Z"
-              }
+      }
+    ],
+    "produces": [
+      "application/json"
+    ],
+    "responses": {
+      "200": {
+        "description": "editedComment",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "6675f038-8c66-4485-9dcf-4660ac27ccd9"
+            },
+            "body": {
+              "type": "string",
+              "example": "Good job"
+            },
+            "userId": {
+              "type": "string",
+              "example": "6675f038-8c76-4485-9dcf-4660ac27dcd9"
+            },
+            "articleId": {
+              "type": "string",
+              "example": "6675f038-8c76-4485-9dcf-2360ac27dcd9"
+            },
+            "articleSlug": {
+              "type": "string",
+              "example": "John-Kamali-6675f038"
+            },
+            "createdAt": {
+              "type": "date",
+              "example": "2019-07-30T14:00:23.458Z"
+            },
+            "updatedAt": {
+              "type": "date",
+              "updatedAt": "2019-07-30T23:22:33.439Z"
             }
           }
-        },
-        "404": {
-          "description": "Comment not found",
-          "schema": {
-            "type": "object",
-            "properties": {
-              "errors": {
-                "type": "object",
-                "properties": {
-                  "message": {
-                    "type": "string",
-                    "example": "Comment not found"
-                  }
+        }
+      },
+      "404": {
+        "description": "Comment not found",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "errors": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Comment not found"
                 }
               }
             }
           }
-        },
-        "401": {
-          "description": "Route accessed without token",
-          "schema": {
+        }
+      }
+    },
+    "401": {
+      "description": "Route accessed without token",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "errors": {
             "type": "object",
             "properties": {
-              "errors": {
-                "type": "object",
-                "properties": {
-                  "message": { "type": "string", "example": "No token provided" }
+              "message": {
+                "type": "string",
+                "example": "No token provided"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "get": {
+    "security": [
+      {
+        "Bearer": []
+      }
+    ],
+    "tags": [
+      "Comments"
+    ],
+    "summary": "Get All Edited Comment History",
+    "description": "Return all edited comment history \n",
+    "parameters": [
+      {
+        "name": "commentId",
+        "in": "path",
+        "required": true,
+        "description": "id of the comment",
+        "schema": {
+          "type": "string",
+          "example": "6675f038-8c66-4485-9dcf-4660ac27ccd9"
+        }
+      }
+    ],
+    "produces": [
+      "application/json"
+    ],
+    "responses": {
+      "200": {
+        "description": "editedComment",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "6675f038-8c66-4485-9dcf-4660ac27ccd9"
+            },
+            "userId": {
+              "type": "string",
+              "example": "6675f038-8c76-4485-9dcf-4660ac27dcd9"
+            },
+            "createdAt": {
+              "type": "date",
+              "example": "2019-07-30T14:00:23.458Z"
+            },
+            "updatedAt": {
+              "type": "date",
+              "example": "2019-07-30T23:22:33.439Z"
+            }
+          }
+        }
+      },
+      "404": {
+        "description": "Comment not found",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "errors": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Comment does not have edit history"
+                }
+              }
+            }
+          }
+        }
+      },
+      "401": {
+        "description": "Route accessed without token",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "errors": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "No token provided"
                 }
               }
             }
@@ -102,3 +195,4 @@
       }
     }
   }
+}

--- a/docs/index.js
+++ b/docs/index.js
@@ -37,7 +37,7 @@ import createUser from './admin/createUser.json';
 import updateDeleteUser from './admin/updateDeleteUser.json';
 import editComment from './comments/editComment.json';
 import getTags from './articles/getTags.json';
-
+import getCommentHistory from './admin/getCommentHistory.json';
 import getReportedArticles from './admin/getReportedArticles.json';
 import likeComment from './comments/likeComment.json';
 import banUser from './admin/banUser.json';
@@ -83,10 +83,9 @@ swagger.paths['/statistics/read'] = myReadCount;
 swagger.paths['/admin/users'] = createUser;
 swagger.paths['/admin/users/{id}'] = updateDeleteUser;
 swagger.paths['/comments/{commentId}'] = editComment;
-
+swagger.paths['/admin/comments/{commentId}'] = getCommentHistory;
 swagger.paths['/comments/likes/{commentId}'] = likeComment;
 swagger.paths['/admin/ban/{id}'] = banUser;
 swagger.paths['/admin/unban/{id}'] = unbanUser;
-
 
 export default swagger;

--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import AdminController from '../controllers/AdminController';
 import AuthController from '../controllers/AuthController';
+import CommentController from '../controllers/CommentController';
 import AuthMiddleware from '../middlewares/Authentication';
 import Validate from '../middlewares/inputValidation';
 import ArticleController from '../controllers/ArticleController';
@@ -15,7 +16,7 @@ const {
 } = AdminController;
 const { verifyToken, verifySuperAdmin, verifyAdmins } = AuthMiddleware;
 const { getReportedArticles } = ArticleController;
-
+const { getEditCommentHistory } = CommentController;
 const router = Router();
 
 router.post('/users', verifyToken, verifySuperAdmin, Validate.signup, signUp);
@@ -26,4 +27,5 @@ router.get('/reportedarticles', verifyToken, verifyAdmins, getReportedArticles);
 router.patch('/ban/:id', verifyToken, verifyAdmins, banUser);
 router.patch('/unban/:id', verifyToken, verifyAdmins, unbanUser);
 
+router.get('/comments/:commentId', verifyToken, verifyAdmins, getEditCommentHistory);
 export default router;

--- a/routes/commentRoutes.js
+++ b/routes/commentRoutes.js
@@ -10,4 +10,5 @@ const { verifyToken, verifiedUserOnly } = AuthMiddleware;
 router.post('/likes/:commentId', verifyToken, verifiedUserOnly, likeComment);
 router.patch('/:commentId', verifyToken, verifiedUserOnly, commentValidate.comment, editComment);
 
+
 export default router;


### PR DESCRIPTION
### What does this PR do?
- user can see previous versions of comments
- adds tests to cover edge cases
- add swagger documentation
#### Description of Task to be completed?
As a user, I should be able to see the previous versions of comments made on an article after previous edits.
![API Flowchart (7)](https://user-images.githubusercontent.com/28678648/63091942-fe3d4900-bf57-11e9-9cbc-b54675156156.png)


#### How should this be manually tested?
After cloning this repo, `cd` into it and do the following:

```bash
# fetch this branch
$ git fetch origin  ft-comment-edit-history-167165082

# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run server
```
Using postman, run /api/v1/admin/comments/{id} 

#### What are the relevant pivotal tracker stories?
[#1167165082](https://www.pivotaltracker.com/story/show/167165082)

#### Screenshots (if appropriate)
<img width="1133" alt="Screenshot 2019-08-15 at 12 01 02" src="https://user-images.githubusercontent.com/28678648/63091007-f16b2600-bf54-11e9-9e13-640b69e88c3f.png">

