### PR TITLE
#167917825 Add Count To Get All Users/Articles

### DIFF
--- a/__tests__/admin.test.js
+++ b/__tests__/admin.test.js
@@ -34,9 +34,9 @@ describe('Admin Routes', () => {
       .set('Authorization', `Bearer ${verifiedUserToken}`)
       .end((err, res) => {
         expect(res.status).to.eql(200);
-        expect(res.body.users[0]).to.have.property('id');
-        expect(res.body.users[0]).to.have.property('firstName');
-        expect(res.body.users[0]).to.have.property('lastName');
+        expect(res.body.allUsers.users[0]).to.have.property('id');
+        expect(res.body.allUsers.users[0]).to.have.property('firstName');
+        expect(res.body.allUsers.users[0]).to.have.property('lastName');
         done();
       });
   });

--- a/__tests__/articleRoutes.test.js
+++ b/__tests__/articleRoutes.test.js
@@ -250,8 +250,8 @@ describe('Article Routes Test', () => {
       .end((err, res) => {
         expect(res.status).to.be.eql(200);
         expect(res.body).to.have.property('articles');
-        expect(res.body.articles).to.be.to.a('array');
-        expect(res.body.articles.length).to.eql(1);
+        expect(res.body.articles.allArticles).to.be.a('array');
+        expect(res.body.articles.allArticles.length).to.eql(1);
         done();
       });
   });

--- a/controllers/AdminController.js
+++ b/controllers/AdminController.js
@@ -27,12 +27,13 @@ export default class AdminController {
     try {
       const { page, limit } = req.query;
       const pageNumber = pagination(page, limit);
-      const allUsers = await User.findAll({
+      const allUsers = await User.findAndCountAll({
         offset: pageNumber.offset,
         limit: pageNumber.limit,
         attributes: ['id', 'email', 'firstName', 'lastName', 'type', 'createdAt']
       });
-      return successResponse(res, 200, 'users', allUsers);
+      const { rows: users, count: usersCount } = allUsers;
+      return successResponse(res, 200, 'allUsers', { usersCount, users });
     } catch (err) {
       return next(err);
     }

--- a/controllers/ArticleController.js
+++ b/controllers/ArticleController.js
@@ -147,7 +147,7 @@ export default class ArticleController {
       const { tag, page, limit } = req.query;
       const pageNumber = pagination(page, limit);
       if (tag) {
-        articles = await Article.findAll({
+        articles = await Article.findAndCountAll({
           offset: pageNumber.offset,
           limit: pageNumber.limit,
           subQuery: false,
@@ -181,10 +181,11 @@ export default class ArticleController {
             },
           ],
         });
-        return successResponse(res, 200, 'articles', articles);
+        const { rows: allArticles, count: articlesCount } = articles;
+        return successResponse(res, 200, 'articles', { articlesCount, allArticles });
       }
 
-      articles = await Article.findAll({
+      articles = await Article.findAndCountAll({
         offset: pageNumber.offset,
         limit: pageNumber.limit,
         subQuery: false,
@@ -215,8 +216,8 @@ export default class ArticleController {
           },
         ],
       });
-
-      return successResponse(res, 200, 'articles', articles);
+      const { rows: allArticles, count: articlesCount } = articles;
+      return successResponse(res, 200, 'articles', { articlesCount, allArticles });
     } catch (err) {
       return next(err);
     }


### PR DESCRIPTION
#### What does this PR do?
implements count to articles and users controllers to get the total number
#### Description of Task to be completed?
The total number of articles/users is returned with the articles/users

#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)
<img width="1133" alt="Screenshot 2019-08-15 at 15 04 43" src="https://user-images.githubusercontent.com/28678648/63105867-91d34180-bf79-11e9-8bc3-d1f56f4d29fd.png">
<img width="1133" alt="Screenshot 2019-08-15 at 15 04 27" src="https://user-images.githubusercontent.com/28678648/63105877-95ff5f00-bf79-11e9-9bd5-8eb8e4aae73a.png">
