### PR TITLE
#167998605 Fix responses on social login & article likes

### DIFF
--- a/__tests__/likes.test.js
+++ b/__tests__/likes.test.js
@@ -35,8 +35,9 @@ describe('Testing /like & /dislike endpoints', () => {
       .set('Authorization', `Bearer ${validToken}`)
       .end((err, res) => {
         expect(res.status).to.eql(201);
-        expect(res.body).to.have.property('message');
-        expect(res.body.message).to.eql("You just liked 'Building APIs with Nodejs'");
+        expect(res.body).to.have.property('article');
+        expect(res.body.article).to.have.property('message');
+        expect(res.body.article.message).to.eql("You just liked 'Building APIs with Nodejs'");
         done();
       });
   });
@@ -46,9 +47,10 @@ describe('Testing /like & /dislike endpoints', () => {
       .post(`${url}/building-apis-with-nodejs-48458493/like`)
       .set('Authorization', `Bearer ${validToken}`)
       .end((err, res) => {
-        expect(res.status).to.eql(201);
-        expect(res.body).to.have.property('message');
-        expect(res.body.message).to.eql("Your like on 'Building APIs with Nodejs' has been removed");
+        expect(res.status).to.eql(200);
+        expect(res.body).to.have.property('article');
+        expect(res.body.article).to.have.property('message');
+        expect(res.body.article.message).to.eql("Your like on 'Building APIs with Nodejs' has been removed");
         done();
       });
   });
@@ -58,9 +60,9 @@ describe('Testing /like & /dislike endpoints', () => {
       .post(`${url}/building-apis-with-nodejs-48458493/dislike`)
       .set('Authorization', `Bearer ${validToken}`)
       .end((err, res) => {
-        expect(res.status).to.eql(201);
-        expect(res.body).to.have.property('message');
-        expect(res.body.message).to.eql("You just disliked 'Building APIs with Nodejs'");
+        expect(res.status).to.eql(201); expect(res.body).to.have.property('article');
+        expect(res.body.article).to.have.property('message');
+        expect(res.body.article.message).to.eql("You just disliked 'Building APIs with Nodejs'");
         done();
       });
   });
@@ -71,8 +73,9 @@ describe('Testing /like & /dislike endpoints', () => {
       .set('Authorization', `Bearer ${validToken}`)
       .end((err, res) => {
         expect(res.status).to.eql(201);
-        expect(res.body).to.have.property('message');
-        expect(res.body.message).to.eql("You just liked 'Building APIs with Nodejs'");
+        expect(res.body).to.have.property('article');
+        expect(res.body.article).to.have.property('message');
+        expect(res.body.article.message).to.eql("You just liked 'Building APIs with Nodejs'");
         done();
       });
   });
@@ -83,8 +86,9 @@ describe('Testing /like & /dislike endpoints', () => {
       .set('Authorization', `Bearer ${validToken}`)
       .end((err, res) => {
         expect(res.status).to.eql(201);
-        expect(res.body).to.have.property('message');
-        expect(res.body.message).to.eql("You just disliked 'Building APIs with Nodejs'");
+        expect(res.body).to.have.property('article');
+        expect(res.body.article).to.have.property('message');
+        expect(res.body.article.message).to.eql("You just disliked 'Building APIs with Nodejs'");
         done();
       });
   });
@@ -96,8 +100,9 @@ describe('Testing /like & /dislike endpoints', () => {
       .set('Authorization', `Bearer ${validToken}`)
       .end((err, res) => {
         expect(res.status).to.eql(201);
-        expect(res.body).to.have.property('message');
-        expect(res.body.message).to.eql("You just disliked 'Some title'");
+        expect(res.body).to.have.property('article');
+        expect(res.body.article).to.have.property('message');
+        expect(res.body.article.message).to.eql("You just disliked 'Some title'");
         done();
       });
   });
@@ -107,9 +112,10 @@ describe('Testing /like & /dislike endpoints', () => {
       .post(`${url}/some-slug/dislike`)
       .set('Authorization', `Bearer ${validToken}`)
       .end((err, res) => {
-        expect(res.status).to.eql(201);
-        expect(res.body).to.have.property('message');
-        expect(res.body.message).to.eql("Your dislike on 'Some title' has been removed");
+        expect(res.status).to.eql(200);
+        expect(res.body).to.have.property('article');
+        expect(res.body.article).to.have.property('message');
+        expect(res.body.article.message).to.eql("Your dislike on 'Some title' has been removed");
         done();
       });
   });

--- a/controllers/ArticleController.js
+++ b/controllers/ArticleController.js
@@ -113,12 +113,12 @@ export default class ArticleController {
                 }]
               },
               { // Comment Thread
-                model: models.Comment,
+                model: Comment,
                 as: 'childComments',
                 attributes: ['id', 'body', 'likes', 'createdAt', 'updatedAt'],
                 include: [
                   { // user
-                    model: models.User,
+                    model: User,
                     as: 'user',
                     attributes: ['firstName', 'lastName', 'email', 'id'],
                     include: [{

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -148,23 +148,21 @@ export default class AuthController {
           password: 'NULL',
         }
       });
+
+      const {
+        id, isVerified, type
+      } = createdUser[0];
+
       const token = Helper.createToken({
-        id: createdUser.id,
-        email: userData.email
+        id,
+        firstName,
+        lastName,
+        email,
+        isVerified,
+        type,
       });
 
-      const { id, isVerified } = createdUser[0];
-
-      return res.status(201).json({
-        user: {
-          token,
-          id,
-          firstName,
-          lastName,
-          email,
-          isVerified,
-        },
-      });
+      return successResponse(res, 200, 'user', { message: 'You have successfully logged in', token });
     } catch (error) {
       /* istanbul ignore next-line */
       return next(error);

--- a/controllers/LikesController.js
+++ b/controllers/LikesController.js
@@ -43,8 +43,8 @@ export default class likeController {
         );
 
         return successResponse(
-          res, 201, 'message',
-          `Your like on '${article.dataValues.title}' has been removed`
+          res, 200, 'article',
+          { message: `Your like on '${article.dataValues.title}' has been removed` }
         );
       }
       // Check if user previously disliked article (change dislike to like if true)
@@ -63,8 +63,8 @@ export default class likeController {
           { where: { slug } },
         );
         return successResponse(
-          res, 201, 'message',
-          `You just liked '${article.dataValues.title}'`,
+          res, 201, 'article',
+          { message: `You just liked '${article.dataValues.title}'` }
         );
       }
 
@@ -82,8 +82,8 @@ export default class likeController {
       );
 
       return successResponse(
-        res, 201, 'message',
-        `You just liked '${article.dataValues.title}'`,
+        res, 201, 'article',
+        { message: `You just liked '${article.dataValues.title}'` }
       );
     } catch (error) {
       return next(error);
@@ -120,8 +120,8 @@ export default class likeController {
         );
 
         return successResponse(
-          res, 201, 'message',
-          `Your dislike on '${article.dataValues.title}' has been removed`
+          res, 200, 'article',
+          { message: `Your dislike on '${article.dataValues.title}' has been removed` }
         );
       }
       // Check if user previously liked article (change like to dislike if true)
@@ -140,8 +140,8 @@ export default class likeController {
         );
 
         return successResponse(
-          res, 201, 'message',
-          `You just disliked '${article.dataValues.title}'`
+          res, 201, 'article',
+          { message: `You just disliked '${article.dataValues.title}'` }
         );
       }
 
@@ -159,8 +159,8 @@ export default class likeController {
       );
 
       return successResponse(
-        res, 201, 'message',
-        `You just disliked '${article.dataValues.title}'`
+        res, 201, 'article',
+        { message: `You just disliked '${article.dataValues.title}'` }
       );
     } catch (error) {
       return next(error);


### PR DESCRIPTION
### What does this PR do?
Updates response sent to the user on login && on liking an article

#### Description of Task to be completed?
- Modify social-login response to follow teams convention
- Modify article-likes response to follow teams convention

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- [#167998605](https://www.pivotaltracker.com/story/show/167998605)

#### Screenshots (if appropriate)
<img width="785" alt="Screenshot 2019-08-20 at 2 20 22 PM" src="https://user-images.githubusercontent.com/20531075/63350762-eb5eb600-c355-11e9-9ff8-faee1bdebca4.png">
<img width="764" alt="Screenshot 2019-08-20 at 2 20 52 PM" src="https://user-images.githubusercontent.com/20531075/63350768-eef23d00-c355-11e9-9f71-868dab889ca3.png">
