### PR TITLE
#168376042 Add author profile in article search results

### DIFF
--- a/controllers/searchController.js
+++ b/controllers/searchController.js
@@ -59,7 +59,11 @@ class SearchController {
           {
             model: User,
             as: 'author',
-            attributes: ['firstName', 'lastName'],
+            attributes: ['id', 'firstName', 'lastName', 'email'],
+            include: [{
+              model: Profile,
+              as: 'profile',
+            }]
           }
         ],
         order: [


### PR DESCRIPTION
### What does this PR do?
Adds author profile to matching article response

#### Description of Task to be completed?
When performing a search on the route `GET /api/v1/search?keyword=`, if an article is found, then the author's profile should be included in the response of the request

#### How should this be manually tested?
After cloning this repo, `cd` into it and do the following:

```bash
# fetch this branch
$ git fetch origin  bg-fix-article-search-response-168376042

# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run server
```
Using postman, visit the route stated above with a keyword as the search parameter.

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#168376042](https://www.pivotaltracker.com/story/show/168376042)

#### Screenshots (if appropriate)
*Newly added profile details*

<img width="1680" alt="Screenshot 2019-09-09 at 2 31 44 PM" src="https://user-images.githubusercontent.com/42325628/64535382-1a41c980-d30f-11e9-8a84-cf75c622cde2.png">
