### PR TITLE
#168453025 Bugfix To Add User and Profile Object to Create Comment

### DIFF
--- a/controllers/CommentController.js
+++ b/controllers/CommentController.js
@@ -6,6 +6,8 @@ const { successResponse, errorResponse } = ServerResponse;
 const {
   Comment,
   Like,
+  User,
+  Profile,
   Article,
   CommentHistory
 } = models;
@@ -45,8 +47,21 @@ export default class CommentController {
           highlightedText,
           containsHighlightedText: true,
         });
+        const userWithProfile = await User.findOne({
+          where: { id: userId },
+          include: [
+            {
+              model: Profile,
+              as: 'profile',
+            },
+          ]
+        });
+        const response = {
+          ...articleComment.dataValues,
+          user: userWithProfile,
+        };
         Notification.newComment(slug, id, title, firstName, lastName);
-        return successResponse(res, 201, 'comment', articleComment.dataValues);
+        return successResponse(res, 201, 'comment', response);
       }
 
       // Threaded comments
@@ -67,8 +82,21 @@ export default class CommentController {
 
         // Create relationship
         await parentComment.addChildComments(newChildComment);
+        const userWithProfile = await User.findOne({
+          where: { id: userId },
+          include: [
+            {
+              model: Profile,
+              as: 'profile',
+            },
+          ]
+        });
+        const response = {
+          ...newChildComment.dataValues,
+          user: userWithProfile,
+        };
 
-        return successResponse(res, 201, 'comment', newChildComment.dataValues);
+        return successResponse(res, 201, 'comment', response);
       }
 
       const articleComment = await Comment.create({
@@ -78,8 +106,20 @@ export default class CommentController {
         articleSlug: slug,
       });
       Notification.newComment(slug, id, title, firstName, lastName);
-
-      return successResponse(res, 201, 'comment', articleComment.dataValues);
+      const userWithProfile = await User.findOne({
+        where: { id: userId },
+        include: [
+          {
+            model: Profile,
+            as: 'profile',
+          },
+        ]
+      });
+      const response = {
+        ...articleComment.dataValues,
+        user: userWithProfile,
+      };
+      return successResponse(res, 201, 'comment', response);
     } catch (error) {
       return next(error);
     }


### PR DESCRIPTION
### What does this PR do?
Adds user and profile objects in comments when fetching a single article

#### Description of Task to be completed?
Includes the user details and profile details to the comment response

#### How should this be manually tested?
git fetch origin bg-adds-user-profile-comment-168453025
send a post request to the comment endpoint

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#168453025](https://www.pivotaltracker.com/story/show/168453025)

#### Screenshots (if appropriate)