### PR TITLE
#168462435 Remove protection from view profile and view user followers routes

### DIFF
--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -22,10 +22,10 @@ const { verifyToken } = AuthMiddlewware;
 const router = Router();
 
 router.patch('/:id', verifyToken, editProfileValidate, editProfile);
-router.get('/:id', verifyToken, validateId, viewProfile);
+router.get('/:id', validateId, viewProfile);
 router.post('/follow/:id', verifyToken, validateParamsId, follow);
 router.delete('/follow/:id', verifyToken, validateParamsId, unfollow);
-router.get('/followers/:id', verifyToken, validateParamsId, getUserFollowers);
-router.get('/followings/:id', verifyToken, validateParamsId, getUserFollowings);
+router.get('/followers/:id', validateParamsId, getUserFollowers);
+router.get('/followings/:id', validateParamsId, getUserFollowings);
 
 export default router;


### PR DESCRIPTION
### What does this PR do?
Removes token verification when viewing a users profile
Removes token verification when viewing a users followers

#### Description of Task to be completed?
When a user visits the route to view a user's profile at `GET /profiles/{userId}` he should be about to see the author's profile being requested,  this bug fix addresses an issue where a token was required in the header for the request to be successful

#### How should this be manually tested?
After cloning this repo, `cd` into it and do the following:

```bash
# fetch this branch
$ git fetch origin  bg-fix-view-profile-168462435
# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run server
```
Using postman, visit the route stated above

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#168462435](https://www.pivotaltracker.com/story/show/168462435)

#### Screenshots (if appropriate)