### PR TITLE
#168506138 User should have a profile after signing up with social links

### DIFF
--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv';
+import gravatar from 'gravatar';
 import models from '../database/models';
 import Helper from '../helpers/Auth';
 import ServerResponse from '../modules';
@@ -11,9 +12,10 @@ const { successResponse, errorResponse } = ServerResponse;
 const {
   BlacklistedToken,
   User,
+  Profile,
 } = models;
 const { sendResetEmail } = ForgotPasswordEmail;
-const { verified, alreadyVerified, incorrectCredentials } = MarkUps;
+const { alreadyVerified, incorrectCredentials } = MarkUps;
 const { signUpUser } = SignUserUp;
 
 /**
@@ -152,6 +154,19 @@ export default class AuthController {
       const {
         id, isVerified, type
       } = createdUser[0];
+
+      // eslint-disable-next-line no-underscore-dangle
+      if (createdUser[0]._options.isNewRecord) {
+        const avatar = gravatar.url(email, {
+          s: '200',
+          r: 'pg',
+          d: 'mm'
+        });
+        await Profile.create({
+          userId: id,
+          avatar,
+        });
+      }
 
       const token = Helper.createToken({
         id,


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where a user profile is not created when signed up via social links

#### Description of Task to be completed?
When a user signs up to the application via the social links on `/api/v1/auth/google` or `/api/v1/auth/facebook`, a user profile should be generated for them in the database. This bug-fix addresses an issue where the profile wasn't created.

#### How should this be manually tested?
After cloning this repo, `cd` into it and do the following:

```bash
# fetch this branch
$ git fetch origin  bg-fix-create-profile-on-social-auth-168506138
# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run server
```
Using postman, visit the routes stated above

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#168506138](https://www.pivotaltracker.com/story/show/168506138)

#### Screenshots (if appropriate)